### PR TITLE
Nodes status UI refactoring

### DIFF
--- a/app/modules/status/components/stats/SystemsStatusStat.tsx
+++ b/app/modules/status/components/stats/SystemsStatusStat.tsx
@@ -238,15 +238,22 @@ const SystemStatusStat: React.FC<SystemStatusStatProps> = ({
           <LabelBadge color={LabelColor.BLUE}>{ssh.host}</LabelBadge>
         </div>
         <div className='ml-16 mt-3'>
+          <span className='text-sm text-gray-500 mb-6'>
+          Nodes status
+          </span>
           <div className='flex justify-between text-xs text-gray-500 mb-1'>
             <span className='flex items-center gap-3'>
               <span className='flex items-center gap-1'>
                 <span className='inline-block w-2 h-2 rounded-full bg-green-500' />
-                Idle
+                {nodes?.available} Idle
               </span>
               <span className='flex items-center gap-1'>
                 <span className='inline-block w-2 h-2 rounded-full bg-yellow-400' />
-                Alloc
+                {nodes?.allocated} Allocated
+              </span>
+              <span className='flex items-center gap-1'>
+                <span className='inline-block w-2 h-2 rounded-full bg-gray-300' />
+                {nodes?.unavailable} Unavailable
               </span>
             </span>
             {nodes === undefined && <span className='italic text-gray-400'>Loading...</span>}
@@ -255,7 +262,7 @@ const SystemStatusStat: React.FC<SystemStatusStatProps> = ({
             )}
             {nodes != null && (
               <span>
-                {nodes.available + nodes.allocated} / {nodes.total}
+                {nodes.total} Total
               </span>
             )}
           </div>

--- a/app/routes/_app._index.tsx
+++ b/app/routes/_app._index.tsx
@@ -54,6 +54,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
           nodes: {
             available: nodes.filter((n) => nodeState(n) === 'idle').length,
             allocated: nodes.filter((n) => ['alloc', 'allocated'].includes(nodeState(n))).length,
+            unavailable: nodes.length - (nodes.filter((n) => nodeState(n) === 'idle').length + nodes.filter((n) => ['alloc', 'allocated'].includes(nodeState(n))).length),
             total: nodes.length,
           } as SystemNodesOverview,
         }

--- a/app/types/api-status.ts
+++ b/app/types/api-status.ts
@@ -59,6 +59,7 @@ export interface FileSystem {
 export interface SystemNodesOverview {
   available: number
   allocated: number
+  unavailable: number
   total: number
 }
 


### PR DESCRIPTION
Minor refactoring of the nodes status ui:

- Added header "Nodes status"
- Added Counter for each node state
- Unavailable nodes are explicitly called out