### PR TITLE
Align ABORT_DELAY with promiseWithTimeout

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -10,8 +10,9 @@ import { RemixServer } from '@remix-run/react'
 import { renderToPipeableStream } from 'react-dom/server'
 import { createReadableStreamFromReadable } from '@remix-run/node'
 import type { AppLoadContext, EntryContext } from '@remix-run/node'
+import { ABORT_DELAY_MS } from '~/helpers/promise-helper'
 
-const ABORT_DELAY = 20_000
+const ABORT_DELAY = ABORT_DELAY_MS
 
 export default function handleRequest(
   request: Request,

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -11,7 +11,7 @@ import { renderToPipeableStream } from 'react-dom/server'
 import { createReadableStreamFromReadable } from '@remix-run/node'
 import type { AppLoadContext, EntryContext } from '@remix-run/node'
 
-const ABORT_DELAY = 5_000
+const ABORT_DELAY = 20_000
 
 export default function handleRequest(
   request: Request,

--- a/app/helpers/promise-helper.ts
+++ b/app/helpers/promise-helper.ts
@@ -5,9 +5,12 @@
   SPDX-License-Identifier: BSD-3-Clause
 *************************************************************************/
 
+export const ABORT_DELAY_MS = 35_000
+export const DEFERRED_PROMISE_TIMEOUT_MS = Math.floor(ABORT_DELAY_MS * 0.95)
+
 export async function promiseWithTimeout<T>(
   promise: Promise<T>,
-  timeoutMs: number = 30000,
+  timeoutMs: number = DEFERRED_PROMISE_TIMEOUT_MS,
   timeoutMessage: string = 'Request timed out. Please try again.',
 ): Promise<T> {
   // Create a timeout promise that rejects after timeoutMs

--- a/app/routes/_app._index.tsx
+++ b/app/routes/_app._index.tsx
@@ -13,7 +13,7 @@ import type { LoaderFunctionArgs } from '@remix-run/node'
 import logger from '~/logger/logger'
 // helpers
 import { logInfoHttp } from '~/helpers/log-helper'
-import { promiseWithTimeout } from '~/helpers/promise-helper'
+import { promiseWithTimeout, DEFERRED_PROMISE_TIMEOUT_MS } from '~/helpers/promise-helper'
 // utils
 import { authenticator, requireAuth, getAuthAccessToken } from '~/utils/auth.server'
 // contexts
@@ -44,7 +44,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
       try {
         const { nodes } = await promiseWithTimeout(
           getSystemNodes(accessToken, system.name),
-          15000,
+          DEFERRED_PROMISE_TIMEOUT_MS,
           `Loading nodes for ${system.name} timed out.`,
         )
         const nodeState = (n: { state: string | string[] }) =>

--- a/app/routes/_app.compute.systems.$systemName.accounts.$accountName._index.tsx
+++ b/app/routes/_app.compute.systems.$systemName.accounts.$accountName._index.tsx
@@ -12,7 +12,7 @@ import { defer } from '@remix-run/node'
 import logger from '~/logger/logger'
 // helpers
 import { logInfoHttp } from '~/helpers/log-helper'
-import { promiseWithTimeout } from '~/helpers/promise-helper'
+import { promiseWithTimeout, DEFERRED_PROMISE_TIMEOUT_MS } from '~/helpers/promise-helper'
 // utils
 import { getAuthAccessToken, requireAuth, authenticator } from '~/utils/auth.server'
 // apis
@@ -41,7 +41,7 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
   // Call api/s and fetch data - deferred for better UX with timeout protection
   const jobsPromise = promiseWithTimeout(
     getJobs(accessToken, systemName, accountName, allUsers),
-    30000, // 30 seconds timeout
+    DEFERRED_PROMISE_TIMEOUT_MS,
     'Loading jobs took too long. The system might be busy or unavailable.',
   )
   // Return deferred response

--- a/app/routes/_app.compute.systems.$systemName.tsx
+++ b/app/routes/_app.compute.systems.$systemName.tsx
@@ -13,6 +13,7 @@ import type { LoaderFunction, LoaderFunctionArgs } from '@remix-run/node'
 import logger from '~/logger/logger'
 // helpers
 import { logInfoHttp } from '~/helpers/log-helper'
+import { promiseWithTimeout, DEFERRED_PROMISE_TIMEOUT_MS } from '~/helpers/promise-helper'
 // utils
 import { getAuthAccessToken, requireAuth, authenticator } from '~/utils/auth.server'
 // apis
@@ -42,7 +43,10 @@ export const loader: LoaderFunction = async ({ request, params }: LoaderFunction
   // Defer getUserInfo so the page renders immediately while groups load in background.
   // Convert any Response rejection to a plain Error so it serialises through
   // turbo-stream and reaches the ErrorBoundary with the correct message.
-  const userInfoPromise = getUserInfo(accessToken, systemName).catch(async (error) => {
+  const userInfoPromise = promiseWithTimeout(
+    getUserInfo(accessToken, systemName),
+    DEFERRED_PROMISE_TIMEOUT_MS,
+  ).catch(async (error) => {
     if (error instanceof Response) {
       const body = await error.text().catch(() => '')
       throw new Error(`${error.status} ${error.statusText}${body ? ': ' + body : ''}`)

--- a/app/routes/_app.filesystems.systems.$systemName.tsx
+++ b/app/routes/_app.filesystems.systems.$systemName.tsx
@@ -13,6 +13,7 @@ import type { LoaderFunction, LoaderFunctionArgs } from '@remix-run/node'
 import logger from '~/logger/logger'
 // helpers
 import { logInfoHttp } from '~/helpers/log-helper'
+import { promiseWithTimeout, DEFERRED_PROMISE_TIMEOUT_MS } from '~/helpers/promise-helper'
 // utils
 import { getAuthAccessToken, requireAuth, authenticator } from '~/utils/auth.server'
 // apis
@@ -42,7 +43,10 @@ export const loader: LoaderFunction = async ({ request, params }: LoaderFunction
   // Defer getUserInfo so the page renders immediately while groups load in background.
   // Convert any Response rejection to a plain Error so it serialises through
   // turbo-stream and reaches the ErrorBoundary with the correct message.
-  const userInfoPromise = getUserInfo(accessToken, systemName).catch(async (error) => {
+  const userInfoPromise = promiseWithTimeout(
+    getUserInfo(accessToken, systemName),
+    DEFERRED_PROMISE_TIMEOUT_MS,
+  ).catch(async (error) => {
     if (error instanceof Response) {
       const body = await error.text().catch(() => '')
       throw new Error(`${error.status} ${error.statusText}${body ? ': ' + body : ''}`)


### PR DESCRIPTION
Fixes timeout issues caused by a mismatch between backend ABORT_DELAY (5s) triggering before promiseWithTimeout (15s).
