### PR TITLE
Honor healthchek setting

### DIFF
--- a/app/helpers/system-helper.ts
+++ b/app/helpers/system-helper.ts
@@ -41,6 +41,10 @@ const isSystemHealthy = (system: System): SystemHealtyStatus => {
 }
 
 const isSystemHealthyByServiceType = (system: System, serviceType: ServiceType) => {
+  //TODO: replace string "filesystems" with enum ServiceType.filesystem after f7t 2.6.0 release
+  if (!system.probing.services || !system.probing.services["filesystems"]) {
+    return true
+  }
   const servicesHealth = filterServicesHealthByType(system.servicesHealth, serviceType, true)
   return servicesHealth.length > 0
 }
@@ -61,14 +65,20 @@ const getHealthyFileSystemSystems = (systems: System[]) => {
   return healthySystems
 }
 
+
 const isFileSystemHealthy = (system: System, fileSystem: FileSystem) => {
+
+  //TODO: replace string "filesystems" with enum ServiceType.filesystem after f7t 2.6.0 release
+  if (!system.probing.services || !system.probing.services["filesystems"]) {
+    return true
+  }
   const servicesHealth = filterServicesHealthByType(
     system.servicesHealth,
     ServiceType.filesystem,
     true,
   )
   if (!servicesHealth || servicesHealth === null || servicesHealth.length <= 0) {
-    return false
+      return false
   }
   return servicesHealth.find((servicesHealth: ServiceHealth) => {
     return servicesHealth.path === fileSystem.path

--- a/app/types/api-status.ts
+++ b/app/types/api-status.ts
@@ -22,6 +22,7 @@ export enum ServiceType {
   scheduler = 'scheduler',
   ssh = 'ssh',
   filesystem = 'filesystem',
+  external_storage = 's3',  //To be renamed after f7t 2.6.0 release
 }
 
 export enum SystemHealtyStatus {
@@ -92,11 +93,14 @@ export interface ServiceHealth {
   path?: string
 }
 
-export interface SystemProbing {
-  interval: number
+
+export interface ProbingService {
   timeout: number
-  healthyLatency: number
-  healthyLoad: number
+}
+
+export interface SystemProbing {
+  services: { [key: string]: ProbingService } | null
+  interval_check: number
 }
 
 export interface SystemTimeouts {


### PR DESCRIPTION
This PR fixes an issue with disabled health checks.
Now, if a system has no health checks, the filesystem is normally browsable. 