### PR TITLE
Fix job list React errors, timeout handling, and form warning

### DIFF
--- a/app/modules/compute/components/forms/JobSubmitForm.tsx
+++ b/app/modules/compute/components/forms/JobSubmitForm.tsx
@@ -165,6 +165,7 @@ const JobSubmitForm: React.FC<any> = ({ formData, formError }: JobSubmitFormData
                 type='text'
                 name='account'
                 value={formData.accountName}
+                readOnly
                 className='border-gray-300 focus:border-blue-300 focus:ring-blue-300 mt-1 block w-full rounded-md border py-2 px-3 shadow-sm sm:text-sm focus:outline-none'
               />
               {showInputValidation({

--- a/app/modules/compute/components/lists/JobList.tsx
+++ b/app/modules/compute/components/lists/JobList.tsx
@@ -6,7 +6,7 @@
 *************************************************************************/
 
 import React, { useState, useEffect } from 'react'
-import { useNavigate, useSearchParams } from '@remix-run/react'
+import { useNavigate } from '@remix-run/react'
 import {
   CalendarIcon,
   ClockIcon,
@@ -242,9 +242,7 @@ type SystemJobListProps = {
 }
 
 const SystemJobList: React.FC<SystemJobListProps> = ({ jobs }) => {
-  const [searchParams, setSearchParams] = useSearchParams()
-  const initialAllUsers = searchParams.get('allUsers') === 'true'
-  const [allUsers, setAllUsers] = useState<boolean>(jobs?.allUsers ?? initialAllUsers)
+  const [allUsers, setAllUsers] = useState<boolean>(jobs?.allUsers ?? false)
   const [localError, setLocalError] = useState<any>(jobs?.error ?? null)
   const { selectedSystem } = useSystem()
   const { selectedGroup } = useGroup()
@@ -252,14 +250,13 @@ const SystemJobList: React.FC<SystemJobListProps> = ({ jobs }) => {
   const [currentJobs, setCurrentJobs] = useState<Job[]>(sortJobs(jobs?.jobs ?? []))
 
   const onChangeHandler = async (event: any) => {
-    // window.location.href = `/compute/systems/${jobs.system}/accounts/${jobs.account}?allUsers=${event.currentTarget.checked}`
     const checked = event.currentTarget.checked
     setAllUsers(checked)
-    setSearchParams((prev) => {
-      const next = new URLSearchParams(prev)
-      next.set('allUsers', String(checked))
-      return next
-    })
+    // Update URL for bookmarkability without triggering a Remix navigation/loader re-run,
+    // which would cause Suspense to re-suspend and conflict with the in-flight fetchJobs call.
+    const url = new URL(window.location.href)
+    url.searchParams.set('allUsers', String(checked))
+    window.history.replaceState({}, '', url.toString())
     // Trigger immediate fetch for instant feedback with the new value
     await fetchJobs(checked)
   }
@@ -276,7 +273,7 @@ const SystemJobList: React.FC<SystemJobListProps> = ({ jobs }) => {
       )
 
       setCurrentJobs(sortJobs(response?.jobs ?? []))
-      setLocalError(null)
+      setLocalError(response?.error ?? null)
 
       // Ensure minimum display time of 300ms to avoid flickering
       const elapsed = Date.now() - startTime

--- a/app/modules/compute/components/views/JobListView.tsx
+++ b/app/modules/compute/components/views/JobListView.tsx
@@ -5,7 +5,7 @@
   SPDX-License-Identifier: BSD-3-Clause
 *************************************************************************/
 
-import React, { Suspense } from 'react'
+import React, { Suspense, memo } from 'react'
 import { Link, Await } from '@remix-run/react'
 import { PlusIcon } from '@heroicons/react/20/solid'
 // lables
@@ -25,6 +25,17 @@ import { useGroup } from '~/contexts/GroupContext'
 import LoadingSpinner from '~/components/spinners/LoadingSpinner'
 // errors
 import AsyncError from '~/components/errors/AsyncError'
+
+// Isolated from GroupContext re-renders so the dehydrated <Await> boundary inside is
+// never traversed before it resolves, preventing React error #421.
+const JobsPanel = memo(({ jobsPromise }: { jobsPromise: Promise<GetSystemJobsResponse> }) => (
+  <Suspense fallback={<LoadingSpinner title='Loading jobs...' className='py-10' />}>
+    <Await resolve={jobsPromise} errorElement={<AsyncError />}>
+      {(jobs: GetSystemJobsResponse) => <JobList jobs={jobs} />}
+    </Await>
+  </Suspense>
+))
+JobsPanel.displayName = 'JobsPanel'
 
 interface JobListViewProps {
   jobsPromise: Promise<GetSystemJobsResponse>
@@ -53,11 +64,7 @@ const JobListView: React.FC<JobListViewProps> = ({ jobsPromise }: JobListViewPro
         className='mb-4'
         actionsButtons={actionsButtons}
       >
-        <Suspense fallback={<LoadingSpinner title='Loading jobs...' className='py-10' />}>
-          <Await resolve={jobsPromise} errorElement={<AsyncError />}>
-            {(jobs: GetSystemJobsResponse) => <JobList jobs={jobs} />}
-          </Await>
-        </Suspense>
+        <JobsPanel jobsPromise={jobsPromise} />
       </SimplePanel>
     </SimpleView>
   )

--- a/app/routes/_app.compute.systems.$systemName.accounts.$accountName._index.tsx
+++ b/app/routes/_app.compute.systems.$systemName.accounts.$accountName._index.tsx
@@ -12,7 +12,7 @@ import { defer } from '@remix-run/node'
 import logger from '~/logger/logger'
 // helpers
 import { logInfoHttp } from '~/helpers/log-helper'
-import { promiseWithTimeout, DEFERRED_PROMISE_TIMEOUT_MS } from '~/helpers/promise-helper'
+import { promiseWithTimeoutOrDefault, DEFERRED_PROMISE_TIMEOUT_MS } from '~/helpers/promise-helper'
 // utils
 import { getAuthAccessToken, requireAuth } from '~/utils/auth.server'
 // apis
@@ -38,11 +38,19 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
   })
   // Get auth access token
   const accessToken = await getAuthAccessToken(request)
-  // Call api/s and fetch data - deferred for better UX with timeout protection
-  const jobsPromise = promiseWithTimeout(
+  // Call api/s and fetch data - deferred for better UX with timeout protection.
+  // Resolves with an error object on timeout so the job list view renders inline
+  // rather than triggering the route ErrorBoundary.
+  const jobsPromise = promiseWithTimeoutOrDefault(
     getJobs(accessToken, systemName, accountName, allUsers),
     DEFERRED_PROMISE_TIMEOUT_MS,
-    'Loading jobs took too long. The system might be busy or unavailable.',
+    {
+      system: systemName,
+      jobs: [],
+      account: accountName,
+      allUsers,
+      error: { message: 'Loading jobs took too long. The system might be busy or unavailable.' },
+    },
   )
   // Return deferred response
   return defer({ jobsPromise })

--- a/app/routes/_app.compute.systems.$systemName.tsx
+++ b/app/routes/_app.compute.systems.$systemName.tsx
@@ -5,8 +5,8 @@
   SPDX-License-Identifier: BSD-3-Clause
 *************************************************************************/
 
-import { Suspense, useEffect } from 'react'
-import { Await, Outlet, useAsyncValue, useLoaderData, useRouteError } from '@remix-run/react'
+import { useEffect, startTransition } from 'react'
+import { Outlet, useLoaderData, useRouteError } from '@remix-run/react'
 import { defer } from '@remix-run/node'
 import type { LoaderFunction, LoaderFunctionArgs } from '@remix-run/node'
 // loggers
@@ -41,37 +41,42 @@ export const loader: LoaderFunction = async ({ request, params }: LoaderFunction
   // Get path params
   const groupName = params.accountName || null
   // Defer getUserInfo so the page renders immediately while groups load in background.
-  // Convert any Response rejection to a plain Error so it serialises through
-  // turbo-stream and reaches the ErrorBoundary with the correct message.
+  // Resolve with null on any failure (timeout, HTTP error) rather than rejecting —
+  // the page still works because groups are seeded from the URL, and DeferredGroupsLoader
+  // uses optional chaining so null userInfo is handled gracefully.
   const userInfoPromise = promiseWithTimeout(
     getUserInfo(accessToken, systemName),
     DEFERRED_PROMISE_TIMEOUT_MS,
-  ).catch(async (error) => {
-    if (error instanceof Response) {
-      const body = await error.text().catch(() => '')
-      throw new Error(`${error.status} ${error.statusText}${body ? ': ' + body : ''}`)
-    }
-    throw error
+  ).catch((error) => {
+    logger.warn({ error }, `Failed to load user info for system ${systemName}`)
+    return null
   })
   return defer({ userInfoPromise, groupName, systemName })
 }
 
-// Updates GroupContext with the real groups once the deferred data resolves,
-// without causing a remount of the Outlet or child components.
-// groupName is the accountName from the URL (null on the system index page).
-function DeferredGroupsLoader({ groupName }: { groupName: string | null }) {
-  const userInfo = useAsyncValue() as GetUserInfoResponse
+// Awaits the deferred userInfoPromise via .then() rather than <Await> + useAsyncValue,
+// so there is no dehydrated Suspense boundary that can trigger React error #421 during
+// Remix's internal fetchAndApplyManifestPatches hydration pass.
+function GroupsUpdater({
+  promise,
+  groupName,
+}: {
+  promise: Promise<GetUserInfoResponse | null>
+  groupName: string | null
+}) {
   const { setGroups, setSelectedGroupName } = useGroup()
   useEffect(() => {
-    if (userInfo?.groups) {
-      setGroups(userInfo.groups)
-    }
-    // When there is no account in the URL (system index page) use the API's
-    // default group so the client-side redirect in the index knows where to go.
-    if (!groupName && userInfo?.group?.name) {
-      setSelectedGroupName(userInfo.group.name)
-    }
-  }, [userInfo, groupName, setGroups, setSelectedGroupName])
+    Promise.resolve(promise).then((userInfo) => {
+      startTransition(() => {
+        if (userInfo?.groups) {
+          setGroups(userInfo.groups)
+        }
+        if (!groupName && userInfo?.group?.name) {
+          setSelectedGroupName(userInfo.group.name)
+        }
+      })
+    })
+  }, [promise, groupName, setGroups, setSelectedGroupName])
   return null
 }
 
@@ -84,11 +89,7 @@ export default function AppComputeIndexRoute() {
   return (
     <GroupProvider groups={initialGroups} groupName={groupName}>
       {/* Resolve deferred groups and push them into context without remounting children */}
-      <Suspense fallback={null}>
-        <Await resolve={userInfoPromise}>
-          <DeferredGroupsLoader groupName={groupName} />
-        </Await>
-      </Suspense>
+      <GroupsUpdater promise={userInfoPromise} groupName={groupName} />
       <GroupSwitcherPortal
         systemName={systemName}
         basePath='/compute'

--- a/app/routes/_app.filesystems.systems.$systemName.tsx
+++ b/app/routes/_app.filesystems.systems.$systemName.tsx
@@ -5,8 +5,8 @@
   SPDX-License-Identifier: BSD-3-Clause
 *************************************************************************/
 
-import { Suspense, useEffect } from 'react'
-import { Await, Outlet, useAsyncValue, useLoaderData, useRouteError } from '@remix-run/react'
+import { useEffect, startTransition } from 'react'
+import { Outlet, useLoaderData, useRouteError } from '@remix-run/react'
 import { defer } from '@remix-run/node'
 import type { LoaderFunction, LoaderFunctionArgs } from '@remix-run/node'
 // loggers
@@ -41,37 +41,41 @@ export const loader: LoaderFunction = async ({ request, params }: LoaderFunction
   // Get path params
   const groupName = params.accountName || null
   // Defer getUserInfo so the page renders immediately while groups load in background.
-  // Convert any Response rejection to a plain Error so it serialises through
-  // turbo-stream and reaches the ErrorBoundary with the correct message.
+  // Resolve with null on any failure (timeout, HTTP error) rather than rejecting —
+  // the page still works because groups are seeded from the URL.
   const userInfoPromise = promiseWithTimeout(
     getUserInfo(accessToken, systemName),
     DEFERRED_PROMISE_TIMEOUT_MS,
-  ).catch(async (error) => {
-    if (error instanceof Response) {
-      const body = await error.text().catch(() => '')
-      throw new Error(`${error.status} ${error.statusText}${body ? ': ' + body : ''}`)
-    }
-    throw error
+  ).catch((error) => {
+    logger.warn({ error }, `Failed to load user info for system ${systemName}`)
+    return null
   })
   return defer({ userInfoPromise, groupName, systemName })
 }
 
-// Updates GroupContext with the real groups once the deferred data resolves,
-// without causing a remount of the Outlet or child components.
-// groupName is the accountName from the URL (null on the system index page).
-function DeferredGroupsLoader({ groupName }: { groupName: string | null }) {
-  const userInfo = useAsyncValue() as GetUserInfoResponse
+// Awaits the deferred userInfoPromise via .then() rather than <Await> + useAsyncValue,
+// so there is no dehydrated Suspense boundary that can trigger React error #421 during
+// Remix's internal fetchAndApplyManifestPatches hydration pass.
+function GroupsUpdater({
+  promise,
+  groupName,
+}: {
+  promise: Promise<GetUserInfoResponse | null>
+  groupName: string | null
+}) {
   const { setGroups, setSelectedGroupName } = useGroup()
   useEffect(() => {
-    if (userInfo?.groups) {
-      setGroups(userInfo.groups)
-    }
-    // When there is no account in the URL (system index page) use the API's
-    // default group so the client-side redirect in the index knows where to go.
-    if (!groupName && userInfo?.group?.name) {
-      setSelectedGroupName(userInfo.group.name)
-    }
-  }, [userInfo, groupName, setGroups, setSelectedGroupName])
+    Promise.resolve(promise).then((userInfo) => {
+      startTransition(() => {
+        if (userInfo?.groups) {
+          setGroups(userInfo.groups)
+        }
+        if (!groupName && userInfo?.group?.name) {
+          setSelectedGroupName(userInfo.group.name)
+        }
+      })
+    })
+  }, [promise, groupName, setGroups, setSelectedGroupName])
   return null
 }
 
@@ -83,11 +87,7 @@ export default function AppFilesystemsIndexRoute() {
   return (
     <GroupProvider groups={initialGroups} groupName={groupName}>
       {/* Resolve deferred groups and push them into context without remounting children */}
-      <Suspense fallback={null}>
-        <Await resolve={userInfoPromise}>
-          <DeferredGroupsLoader groupName={groupName} />
-        </Await>
-      </Suspense>
+      <GroupsUpdater promise={userInfoPromise} groupName={groupName} />
       <GroupSwitcherPortal
         systemName={systemName}
         basePath='/filesystems'

--- a/server.js
+++ b/server.js
@@ -56,6 +56,11 @@ if (isProd) {
   app.use(vite.middlewares)
 }
 
+// Silently ignore Chrome DevTools well-known probe so it never reaches Remix
+app.get('/.well-known/appspecific/com.chrome.devtools.json', (_req, res) => {
+  res.status(404).end()
+})
+
 // Remix handler
 app.all(
   '*',

--- a/server.js
+++ b/server.js
@@ -56,11 +56,6 @@ if (isProd) {
   app.use(vite.middlewares)
 }
 
-// Silently ignore Chrome DevTools well-known probe so it never reaches Remix
-app.get('/.well-known/appspecific/com.chrome.devtools.json', (_req, res) => {
-  res.status(404).end()
-})
-
 // Remix handler
 app.all(
   '*',


### PR DESCRIPTION
  ## Summary

  - **Fix React error #421 (hydration Suspense conflict)** — three independent causes addressed:
    - Layout routes (`_app.compute.systems.$systemName.tsx`, `_app.filesystems.systems.$systemName.tsx`):
   replaced `<Await>` + `<Suspense>` + `useAsyncValue` with a plain `GroupsUpdater` component that awaits
   the deferred promise via `useEffect` + `Promise.resolve().then()` + `startTransition`, eliminating the
   dehydrated Suspense boundary that Remix's internal `fetchAndApplyManifestPatches` was colliding with
  during hydration.
    - `JobListView.tsx`: wrapped `<Suspense><Await resolve={jobsPromise}>` in a `React.memo`'d
  `JobsPanel` component so that `GroupContext` updates no longer trigger a traversal into the
  still-dehydrated jobs boundary.
    - Filesystem layout route loader: changed `.catch()` from re-throwing to resolving with `null`,
  consistent with the compute route.

  - **Fix "Server Timeout" full-page error on job list**
  (`_app.compute.systems.$systemName.accounts.$accountName._index.tsx`): switched from
  `promiseWithTimeout` (rejects on timeout) to `promiseWithTimeoutOrDefault` (resolves with an error
  object), so a slow or unavailable backend shows an inline message instead of crashing to the route
  `ErrorBoundary`.

  - **Fix "Unexpected Server Error" on All Users toggle** (`JobList.tsx`): replaced `setSearchParams`
  with `window.history.replaceState` to update the URL without triggering a Remix navigation/loader
  re-run, which was causing Suspense re-suspension. Also fixed `setLocalError(null)` →
  `setLocalError(response?.error ?? null)` so errors from a re-fetch are not silently swallowed.

  - **Fix React controlled input warning** (`JobSubmitForm.tsx`): added `readOnly` to the account input
  field.
