### PR TITLE
Fix silent error handling in File Manager transfer dialogs

### DIFF
--- a/app/modules/filesystem/components/dialogs/DownloadDialog.tsx
+++ b/app/modules/filesystem/components/dialogs/DownloadDialog.tsx
@@ -16,6 +16,8 @@ import SimpleDialog from '~/components/dialogs/SimpleDialog'
 import CodeBlock from '~/components/codes/CodeBlock'
 import LabelBadge, { LabelColor } from '~/components/badges/LabelBadge'
 import { postLocalTransferDownload } from '~/apis/filesystem-api'
+// errors
+import AlertError from '~/components/alerts/AlertError'
 
 interface DownloadDialogProps {
   system: string
@@ -84,9 +86,7 @@ const DownloadDialog: React.FC<DownloadDialogProps> = ({
       onClose()
       window.location.href = downloadEndpoint
     } else {
-      postFileTransferDownload(system, getFilePath(), formValues.account).catch((response) => {
-        console.log(response)
-      })
+      postFileTransferDownload(system, getFilePath(), formValues.account)
     }
   }
 
@@ -100,6 +100,7 @@ const DownloadDialog: React.FC<DownloadDialogProps> = ({
       {loading && <LoadingSpinner title='Preparing download...' className='py-10' />}
       {!loading && (
         <>
+          <AlertError error={downloadError ? { message: downloadError } : null} />
           {!downloadUrl && (
             <div className='flex flex-col w-full space-y-4'>
               {needTransferDownload() && (

--- a/app/modules/filesystem/components/dialogs/TransferUploadResultDialog.tsx
+++ b/app/modules/filesystem/components/dialogs/TransferUploadResultDialog.tsx
@@ -8,6 +8,8 @@ import React, { useEffect, useMemo, useState } from 'react'
 // dialogs
 import CodeBlock from '~/components/codes/CodeBlock'
 import TemplatedCodeBlock from '~/components/codes/TemplatedCodeBlock'
+// errors
+import AlertError from '~/components/alerts/AlertError'
 // types
 import { GetTransferUploadResponse } from '~/types/api-filesystem'
 // dialogs
@@ -37,6 +39,7 @@ const TransferUploadResultDialog: React.FC<TransferUploadResultDialogProps> = ({
   const [templateRaw, setTemplateRaw] = useState<string>('')
   const [scriptFilled, setScriptFilled] = useState<string>('')
   const [filePath, setFilePath] = useState<string>(DEFAULT_PATH)
+  const [templateError, setTemplateError] = useState<string | null>(null)
 
   // ---------------------------
   // 📦 Helpers
@@ -59,12 +62,14 @@ const TransferUploadResultDialog: React.FC<TransferUploadResultDialogProps> = ({
   useEffect(() => {
     const loadTemplate = async () => {
       if (!transferResult) return
+      setTemplateError(null)
       try {
         const res = await fetch('/file_upload_script_template.txt')
         const txt = await res.text()
         setTemplateRaw(txt)
       } catch (err) {
         console.error('Failed to load template:', err)
+        setTemplateError('Failed to load the upload script template. Please try again.')
       }
     }
     loadTemplate()
@@ -241,7 +246,11 @@ const TransferUploadResultDialog: React.FC<TransferUploadResultDialogProps> = ({
             </button>
           </div>
 
-          <TemplatedCodeBlock code={scriptFilled} />
+          {templateError ? (
+            <AlertError error={{ message: templateError }} />
+          ) : (
+            <TemplatedCodeBlock code={scriptFilled} />
+          )}
         </section>
 
         {/* 💡 How to use */}


### PR DESCRIPTION
  ## Summary

  - **DownloadDialog**: `downloadError` state was set on backend failure but never rendered — the user
  had no feedback when a transfer download failed. Added `<AlertError>` display and removed a dead
  `.catch()` that was shadowing the internal error handler.
  - **TransferUploadResultDialog**: template fetch failure was silently swallowed with only a
  `console.error`. Added a `templateError` state that renders an `<AlertError>` in place of the blank
  script block so the user knows why the upload script is missing