### PR TITLE
Fix remote script job submission and double slash in filesystem browser

### DIFF
--- a/app/modules/filesystem/components/tables/FileSystemSelectableTable.tsx
+++ b/app/modules/filesystem/components/tables/FileSystemSelectableTable.tsx
@@ -39,7 +39,7 @@ const FileItem: React.FC<FileItemProps> = ({
   mode = RemoteFilesystemBrowserMode.FILE_AND_DIRECTORY,
 }: FileItemProps) => {
   const handleOnSelectTarget = () => {
-    onSelectTarget(system.name, `${currentPath}/${file.name}`)
+    onSelectTarget(system.name, `${currentPath.replace(/\/+$/, '')}/${file.name}`)
   }
   return (
     <tr className='even:bg-blue-50'>
@@ -101,10 +101,10 @@ const DirectoryItem: React.FC<DirectoryItemProps> = ({
   mode = RemoteFilesystemBrowserMode.FILE_AND_DIRECTORY,
 }: DirectoryItemProps) => {
   const handleNavigateTo = () => {
-    onNavigateTo(system.name, `${currentPath}/${file.name}`)
+    onNavigateTo(system.name, `${currentPath.replace(/\/+$/, '')}/${file.name}`)
   }
   const handleOnSelectTarget = () => {
-    onSelectTarget(system.name, `${currentPath}/${file.name}`)
+    onSelectTarget(system.name, `${currentPath.replace(/\/+$/, '')}/${file.name}`)
   }
   return (
     <tr className='even:bg-blue-50'>

--- a/app/types/api-compute.ts
+++ b/app/types/api-compute.ts
@@ -7,8 +7,7 @@
 
 export type JobDescritpion = {
   script?: string
-  script_local_path?: string
-  script_remote_path?: string
+  script_path?: string
   account?: string
   name?: string
   working_directory: string
@@ -47,7 +46,7 @@ export const convertPostJobFormToApiPayload = async (
   return {
     job: {
       script: script,
-      script_remote_path: isRemote ? payload.remoteScript : undefined,
+      script_path: isRemote ? payload.remoteScript : undefined,
       working_directory: payload.workingDirectory,
       account: payload.account,
       name: payload.name


### PR DESCRIPTION
  ## Summary

  - Fixes remote script job submission always returning 422 from Slurm.
    The UI was sending `script_remote_path` but the firecrest-v2
    `JobDescriptionModel` expects `script_path` — causing both `script`
    and `script_path` to be null on the backend, which Slurm rejected with
    _"Populated `script` field is required for job submission"_.
    Also removes the unused `script_local_path` field from `JobDescritpion`.

    browser when `currentPath` ends with `/` (e.g. at filesystem root).
    Affects file selection, directory selection, and navigation in
    `FileSystemSelectableTable`.