### PR TITLE
fix: stream dashboard node stats per system instead of all-or-nothing

### DIFF
--- a/app/modules/dashboard/components/views/DashboardView.tsx
+++ b/app/modules/dashboard/components/views/DashboardView.tsx
@@ -5,8 +5,7 @@
   SPDX-License-Identifier: BSD-3-Clause
 *************************************************************************/
 
-import React, { Suspense } from 'react'
-import { Await } from '@remix-run/react'
+import React from 'react'
 // types
 import type { SystemNodesOverview } from '~/types/api-status'
 // views
@@ -14,23 +13,15 @@ import SimpleView, { SimpleViewSize } from '~/components/views/SimpleView'
 // stats
 import SystemsStatusStat from '~/modules/status/components/stats/SystemsStatusStat'
 
-type SystemsNodes = Record<string, SystemNodesOverview | null>
-
 interface DashboardViewProps {
   systems: any[]
-  systemsNodesPromise: Promise<SystemsNodes>
+  systemsNodesPromises: Record<string, Promise<SystemNodesOverview | null>>
 }
 
-const DashboardView: React.FC<DashboardViewProps> = ({ systems, systemsNodesPromise }) => {
+const DashboardView: React.FC<DashboardViewProps> = ({ systems, systemsNodesPromises }) => {
   return (
     <SimpleView title='Dashboard' size={SimpleViewSize.FULL}>
-      <Suspense fallback={<SystemsStatusStat systems={systems} />}>
-        <Await resolve={systemsNodesPromise} errorElement={<SystemsStatusStat systems={systems} />}>
-          {(systemsNodes: SystemsNodes) => (
-            <SystemsStatusStat systems={systems} systemsNodes={systemsNodes} />
-          )}
-        </Await>
-      </Suspense>
+      <SystemsStatusStat systems={systems} systemsNodesPromises={systemsNodesPromises} />
     </SimpleView>
   )
 }

--- a/app/modules/status/components/stats/SystemsStatusStat.tsx
+++ b/app/modules/status/components/stats/SystemsStatusStat.tsx
@@ -6,7 +6,8 @@
 *************************************************************************/
 
 import _ from 'lodash'
-import React, { useState } from 'react'
+import React, { Suspense, useState } from 'react'
+import { Await } from '@remix-run/react'
 import prettyMilliseconds from 'pretty-ms'
 import {
   CheckCircleIcon,
@@ -310,27 +311,32 @@ const SystemStatusStat: React.FC<SystemStatusStatProps> = ({
   )
 }
 
-const SystemsStatusStatList: React.FC<any> = ({ systems, systemsNodes }) => {
+const SystemsStatusStatList: React.FC<any> = ({ systems, systemsNodesPromises }) => {
   return (
     <div className='mt-2 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-2 items-start'>
       {systems &&
         systems.length > 0 &&
         systems.map((system: any) => (
-          <SystemStatusStat
-            system={system}
-            nodes={systemsNodes?.[system.name]}
-            key={system.name}
-          />
+          <Suspense key={system.name} fallback={<SystemStatusStat system={system} />}>
+            <Await
+              resolve={systemsNodesPromises?.[system.name]}
+              errorElement={<SystemStatusStat system={system} />}
+            >
+              {(nodes: SystemNodesOverview | null) => (
+                <SystemStatusStat system={system} nodes={nodes ?? undefined} />
+              )}
+            </Await>
+          </Suspense>
         ))}
     </div>
   )
 }
 
-const SystemsStatusStat: React.FC<any> = ({ systems, systemsNodes, className = '' }: any) => {
+const SystemsStatusStat: React.FC<any> = ({ systems, systemsNodesPromises, className = '' }: any) => {
   return (
     <div className={classNames('mb-4', className)}>
       <h3 className='text-base font-semibold leading-6 text-gray-900'>Systems status</h3>
-      <SystemsStatusStatList systems={systems} systemsNodes={systemsNodes} />
+      <SystemsStatusStatList systems={systems} systemsNodesPromises={systemsNodesPromises} />
     </div>
   )
 }

--- a/app/routes/_app._index.tsx
+++ b/app/routes/_app._index.tsx
@@ -38,51 +38,46 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   const accessToken = await getAuthAccessToken(request)
   // Call api/s and fetch data
   const { systems } = await getSystems(accessToken, request)
-  // Defer nodes fetching — resolves to a map of system name → nodes health
-  const systemsNodesPromise = Promise.all(
-    systems.map(async (system) => {
-      try {
-        const { nodes } = await promiseWithTimeout(
+  // Defer nodes fetching per system — each resolves independently so fast systems
+  // render immediately without waiting for slow ones (e.g. a single slow /nodes endpoint).
+  const nodeState = (n: { state: string | string[] }) =>
+    (Array.isArray(n.state) ? n.state[0] : n.state).toLowerCase()
+  const systemsNodesPromises: Record<string, Promise<SystemNodesOverview | null>> =
+    Object.fromEntries(
+      systems.map((system) => [
+        system.name,
+        promiseWithTimeout(
           getSystemNodes(accessToken, system.name, request),
           DEFERRED_PROMISE_TIMEOUT_MS,
           `Loading nodes for ${system.name} timed out.`,
         )
-        const nodeState = (n: { state: string | string[] }) =>
-          (Array.isArray(n.state) ? n.state[0] : n.state).toLowerCase()
-        return {
-          name: system.name,
-          nodes: {
+          .then(({ nodes }) => ({
             available: nodes.filter((n) => nodeState(n) === 'idle').length,
             allocated: nodes.filter((n) => ['alloc', 'allocated'].includes(nodeState(n))).length,
-            unavailable: nodes.length - (nodes.filter((n) => nodeState(n) === 'idle').length + nodes.filter((n) => ['alloc', 'allocated'].includes(nodeState(n))).length),
+            unavailable:
+              nodes.length -
+              nodes.filter((n) => nodeState(n) === 'idle').length -
+              nodes.filter((n) => ['alloc', 'allocated'].includes(nodeState(n))).length,
             total: nodes.length,
-          } as SystemNodesOverview,
-        }
-      } catch (error) {
-        const msg = error instanceof Response ? `${error.status} ${error.statusText}` : error
-        console.warn(`Failed to load nodes for system ${system.name}:`, msg)
-        return { name: system.name, nodes: null }
-      }
-    }),
-  ).then((results) => {
-    const systemsNodes: Record<string, SystemNodesOverview | null> = {}
-    for (const result of results) {
-      systemsNodes[result.name] = result.nodes
-    }
-    return systemsNodes
-  })
-  // Return response with deferred promise (defer is needed for Remix v2 streaming)
+          } as SystemNodesOverview))
+          .catch((error) => {
+            const msg = error instanceof Response ? `${error.status} ${error.statusText}` : error
+            console.warn(`Failed to load nodes for system ${system.name}:`, msg)
+            return null
+          }),
+      ]),
+    )
   // eslint-disable-next-line @typescript-eslint/no-deprecated
-  return defer({
-    systems,
-    systemsNodesPromise,
-  })
+  return defer({ systemsNodesPromises })
 }
 
 export default function AppIndexRoute() {
   const { systems } = useSystem()
-  const { systemsNodesPromise } = useLoaderData<typeof loader>()
-  return <DashboardView systems={systems} systemsNodesPromise={systemsNodesPromise} />
+  // Cast needed: Remix's JsonifyObject strips Promise wrappers from deferred loader data
+  const { systemsNodesPromises } = useLoaderData<typeof loader>() as {
+    systemsNodesPromises: Record<string, Promise<SystemNodesOverview | null>>
+  }
+  return <DashboardView systems={systems} systemsNodesPromises={systemsNodesPromises} />
 }
 
 export function ErrorBoundary() {


### PR DESCRIPTION
  ## Problem

  The dashboard fetched all systems' node statistics via a single
  `Promise.all`, then deferred the combined result. Because all systems
  had to resolve before any card could update, a single slow endpoint
  (e.g. `/v2/status/clariden/nodes`) blocked every other system's node
  bars for up to the full 33 s timeout — even when the other backends
  responded in under a second.

  ## Solution

  Replace the shared `Promise.all` with one independent deferred
  `Promise` per system. Each system card gets its own `<Suspense>`
  boundary wrapping a per-system `<Await>`, so the node bars for each
  system stream in as soon as that system's `/nodes` endpoint responds.

  **Before:** all cards show the pulsing skeleton until the slowest
  system resolves (or times out).
  **After:** each card fills in independently; a slow system only delays
  its own card.

  ## Changes

  - `_app._index.tsx` — loader builds `Record<string, Promise<…>>` via
    `Object.fromEntries`; each entry handles its own timeout and error,
    resolving to `null` on failure. Removed the redundant `systems` key
    from the `defer` return (component reads from `useSystem()` context).
  - `DashboardView.tsx` — removed the outer `Suspense`/`Await` wrapper;
    just forwards `systemsNodesPromises` to `SystemsStatusStat`.
  - `SystemsStatusStat.tsx` — `SystemsStatusStatList` now wraps each
    card in its own `<Suspense>` + `<Await>`, importing `Await` from
    `@remix-run/react`.