### PR TITLE
Fix slow root path loading

### DIFF
--- a/app/apis/status-api.ts
+++ b/app/apis/status-api.ts
@@ -16,14 +16,22 @@ import type {
 // apis
 import api, { withRequestId } from './api'
 
+// Deduplicates concurrent calls with the same token (layout + index loaders both call
+// this in parallel for the same request — one HTTP fetch is enough).
+const _pendingSystems = new Map<string, Promise<GetSystemsResponse>>()
+
 export const getSystems = async (
   accessToken: string,
   request: Request | null = null,
 ): Promise<GetSystemsResponse> => {
-  const apiResponse = await api.get<GetSystemsResponse>('/status/systems', {
+  const existing = _pendingSystems.get(accessToken)
+  if (existing) return existing
+  const promise = api.get<GetSystemsResponse>('/status/systems', {
     headers: withRequestId({ Authorization: `Bearer ${accessToken}` }, request),
   })
-  return apiResponse
+  _pendingSystems.set(accessToken, promise)
+  promise.finally(() => _pendingSystems.delete(accessToken))
+  return promise
 }
 
 // Server-side TTL cache for getUserInfo. The data is user/system-specific but

--- a/app/routes/_app._index.tsx
+++ b/app/routes/_app._index.tsx
@@ -5,9 +5,9 @@
   SPDX-License-Identifier: BSD-3-Clause
 *************************************************************************/
 
-import { useLoaderData, useRouteError } from '@remix-run/react'
-// eslint-disable-next-line @typescript-eslint/no-deprecated
-import { defer } from '@remix-run/node'
+import { Suspense } from 'react'
+import { useLoaderData, useRouteError, Await } from '@remix-run/react'
+import { data } from '@remix-run/node'
 import type { LoaderFunctionArgs } from '@remix-run/node'
 // loggers
 // helpers
@@ -25,6 +25,8 @@ import type { SystemNodesOverview } from '~/types/api-status'
 // views
 import ErrorView from '~/components/views/ErrorView'
 import DashboardView from '~/modules/dashboard/components/views/DashboardView'
+// spinners
+import LoadingSpinner from '~/components/spinners/LoadingSpinner'
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   // Check authentication
@@ -36,13 +38,11 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   })
   // Get auth access token
   const accessToken = await getAuthAccessToken(request)
-  // Call api/s and fetch data
-  const { systems } = await getSystems(accessToken, request)
-  // Defer nodes fetching per system — each resolves independently so fast systems
-  // render immediately without waiting for slow ones (e.g. a single slow /nodes endpoint).
+  // Chain getSystems (shared deduped promise) into per-system node promises without
+  // awaiting — loader returns immediately so the shell renders before the HTTP call.
   const nodeState = (n: { state: string | string[] }) =>
     (Array.isArray(n.state) ? n.state[0] : n.state).toLowerCase()
-  const systemsNodesPromises: Record<string, Promise<SystemNodesOverview | null>> =
+  const systemsNodesPromise = getSystems(accessToken, request).then(({ systems }) =>
     Object.fromEntries(
       systems.map((system) => [
         system.name,
@@ -66,18 +66,26 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
             return null
           }),
       ]),
-    )
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
-  return defer({ systemsNodesPromises })
+    ) as Record<string, Promise<SystemNodesOverview | null>>,
+  )
+  return data({ systemsNodesPromise })
 }
 
 export default function AppIndexRoute() {
   const { systems } = useSystem()
   // Cast needed: Remix's JsonifyObject strips Promise wrappers from deferred loader data
-  const { systemsNodesPromises } = useLoaderData<typeof loader>() as {
-    systemsNodesPromises: Record<string, Promise<SystemNodesOverview | null>>
+  const { systemsNodesPromise } = useLoaderData<typeof loader>() as unknown as {
+    systemsNodesPromise: Promise<Record<string, Promise<SystemNodesOverview | null>>>
   }
-  return <DashboardView systems={systems} systemsNodesPromises={systemsNodesPromises} />
+  return (
+    <Suspense fallback={<LoadingSpinner className='h-full' />}>
+      <Await resolve={systemsNodesPromise}>
+        {(systemsNodesPromises) => (
+          <DashboardView systems={systems} systemsNodesPromises={systemsNodesPromises} />
+        )}
+      </Await>
+    </Suspense>
+  )
 }
 
 export function ErrorBoundary() {

--- a/app/routes/_app.tsx
+++ b/app/routes/_app.tsx
@@ -5,8 +5,9 @@
   SPDX-License-Identifier: BSD-3-Clause
 *************************************************************************/
 
-import { json } from '@remix-run/node'
-import { useLoaderData } from '@remix-run/react'
+import { Suspense } from 'react'
+import { data } from '@remix-run/node'
+import { useLoaderData, Await } from '@remix-run/react'
 import type { LinksFunction, LoaderFunction, LoaderFunctionArgs } from '@remix-run/node'
 // styles
 import stylesheet from '~/styles/app.css?url'
@@ -21,6 +22,10 @@ import { getNotificationMessage } from '~/helpers/notification-helper'
 // utils
 import { requireAuth, getAuthAccessToken } from '~/utils/auth.server'
 import { SystemProvider } from '~/contexts/SystemContext'
+// spinners
+import LoadingSpinner from '~/components/spinners/LoadingSpinner'
+// types
+import type { System } from '~/types/api-status'
 
 export const links: LinksFunction = () => [{ rel: 'stylesheet', href: stylesheet }]
 
@@ -35,10 +40,9 @@ export const loader: LoaderFunction = async ({ request, params }: LoaderFunction
   const headers = new Headers()
   // Get notification messages
   const notificationMessages = await getNotificationMessage(request, headers)
-  // Call api/s and fetch data
-  const { systems } = await getSystems(accessToken, request)
-  // Return json
-  return json(
+  // Fire getSystems without awaiting — page renders immediately, systems stream in
+  const systemsPromise = getSystems(accessToken, request).then(({ systems }) => systems)
+  return data(
     {
       environment: base.environment,
       appName: base.appName,
@@ -50,17 +54,14 @@ export const loader: LoaderFunction = async ({ request, params }: LoaderFunction
       logoPath: base.logoPath,
       authUser: auth.user,
       notificationMessages: notificationMessages,
-      systems: systems,
       systemName,
+      systemsPromise,
     },
-    {
-      headers: headers,
-    },
+    { headers },
   )
 }
 
 export default function AppLayoutRoute() {
-  const data = useLoaderData()
   const {
     appName,
     appVersion,
@@ -72,23 +73,30 @@ export default function AppLayoutRoute() {
     environment,
     authUser,
     notificationMessages,
-    systems,
     systemName,
-  }: any = data
+    systemsPromise,
+  }: any = useLoaderData()
+
   return (
-    <SystemProvider systems={systems} systemName={systemName}>
-      <AppLayout
-        appName={appName}
-        environment={environment}
-        appVersion={appVersion}
-        companyName={companyName}
-        logoPath={logoPath}
-        supportUrl={supportUrl}
-        repoUrl={repoUrl}
-        docUrl={docUrl}
-        authUser={authUser}
-        notificationMessages={notificationMessages}
-      />
-    </SystemProvider>
+    <Suspense fallback={<LoadingSpinner title='Loading systems...' className='h-screen' />}>
+      <Await resolve={systemsPromise}>
+        {(systems: System[]) => (
+          <SystemProvider systems={systems} systemName={systemName}>
+            <AppLayout
+              appName={appName}
+              environment={environment}
+              appVersion={appVersion}
+              companyName={companyName}
+              logoPath={logoPath}
+              supportUrl={supportUrl}
+              repoUrl={repoUrl}
+              docUrl={docUrl}
+              authUser={authUser}
+              notificationMessages={notificationMessages}
+            />
+          </SystemProvider>
+        )}
+      </Await>
+    </Suspense>
   )
 }

--- a/app/utils/auth.server.ts
+++ b/app/utils/auth.server.ts
@@ -175,6 +175,12 @@ export async function requireAuth(request: Request, failureRedirect = '/login') 
   return { auth, returnTo }
 }
 
+// Deduplicates concurrent token refresh attempts for the same session.
+// Remix runs all matched route loaders in parallel; without this, two loaders
+// hitting an expired token at the same time would both try to use the same
+// single-use refresh token — the second call would fail and trigger logout.
+const _pendingRefresh = new Map<string, Promise<string>>()
+
 // TODO: Refactoring and code optimization
 export async function getAuthAccessToken(request: Request, headers = new Headers()) {
   try {
@@ -199,28 +205,38 @@ export async function getAuthAccessToken(request: Request, headers = new Headers
     return authTokens.accessToken
   } catch (error) {
     if (error instanceof AuthorizationError) {
-      const auth = await getAuth(request)
-      const { access_token, refresh_token, expires_in } = await refreshAccessToken(
-        request,
-        auth.tokens.refreshToken,
-      )
-      const expirationDate = new Date()
-      expirationDate.setSeconds(expirationDate.getSeconds() + expires_in - oidc.tokenExpirationBuffer)
-      auth.tokens = {
-        accessToken: access_token,
-        refreshToken: refresh_token,
-        expirationDate: expirationDate,
+      const cookieKey = request.headers.get('Cookie') ?? ''
+      const existing = _pendingRefresh.get(cookieKey)
+      if (existing) {
+        return existing
       }
-      const session = await getSession(request.headers.get('Cookie'))
-      session.set(AUTH_SESSION_KEY, auth)
-      headers.append('Set-Cookie', await sessionStorage.commitSession(session))
-      if (request.method === 'GET') {
-        const url = request.url
-        if (url.indexOf('/api/') < 0) {
-          throw redirect(url, { headers })
+      const refreshPromise = (async () => {
+        const auth = await getAuth(request)
+        const { access_token, refresh_token, expires_in } = await refreshAccessToken(
+          request,
+          auth.tokens.refreshToken,
+        )
+        const expirationDate = new Date()
+        expirationDate.setSeconds(expirationDate.getSeconds() + expires_in - oidc.tokenExpirationBuffer)
+        auth.tokens = {
+          accessToken: access_token,
+          refreshToken: refresh_token,
+          expirationDate: expirationDate,
         }
-      }
-      return access_token
+        const session = await getSession(request.headers.get('Cookie'))
+        session.set(AUTH_SESSION_KEY, auth)
+        headers.append('Set-Cookie', await sessionStorage.commitSession(session))
+        if (request.method === 'GET') {
+          const url = request.url
+          if (url.indexOf('/api/') < 0) {
+            throw redirect(url, { headers })
+          }
+        }
+        return access_token
+      })()
+      _pendingRefresh.set(cookieKey, refreshPromise)
+      refreshPromise.finally(() => _pendingRefresh.delete(cookieKey))
+      return refreshPromise
     }
     throw error
   }


### PR DESCRIPTION
This PR contains multiple improvements to reduce the root path loading time:

- Fixes auth race condition when multiple components request a JWT token
- Fixes multiple concurrent requests to /systems/status
- Requests to /systems/status are deferred a spinner is displayed while the request completes  