### PR TITLE
fix/feat: dashboard client-side loading and backend latency observability

### DIFF
--- a/app/apis/api.ts
+++ b/app/apis/api.ts
@@ -8,6 +8,8 @@
 import { ReasonPhrases, StatusCodes, getReasonPhrase } from 'http-status-codes'
 // configs
 import firecrest from '~/configs/firecrest.config'
+// logger
+import logger from '~/logger/logger.server'
 
 export enum ApiTarget {
   API_LOCAL = 0,
@@ -32,7 +34,21 @@ async function request<TResponse>(
   config: RequestInit = {},
   jsonResponse: ResponseBodyType = ResponseBodyType.JSON,
 ): Promise<TResponse> {
+  const t = performance.now()
   const response = await fetch(buildUrl(url, target), config)
+  const durationMs = Math.round(performance.now() - t)
+  const fields = {
+    'event.action': 'api.request',
+    'event.duration': durationMs * 1_000_000,
+    'url.path': url,
+    'http.response.status_code': response.status,
+    component: 'firecrest',
+  }
+  if (durationMs > 2_000) {
+    logger.warn(fields, `Slow api.request: ${url} ${durationMs}ms`)
+  } else {
+    logger.debug(fields, `api.request`)
+  }
   return await handleReponse(response, target, jsonResponse)
 }
 

--- a/app/apis/api.ts
+++ b/app/apis/api.ts
@@ -8,8 +8,6 @@
 import { ReasonPhrases, StatusCodes, getReasonPhrase } from 'http-status-codes'
 // configs
 import firecrest from '~/configs/firecrest.config'
-// logger
-import logger from '~/logger/logger.server'
 
 export enum ApiTarget {
   API_LOCAL = 0,
@@ -34,21 +32,7 @@ async function request<TResponse>(
   config: RequestInit = {},
   jsonResponse: ResponseBodyType = ResponseBodyType.JSON,
 ): Promise<TResponse> {
-  const t = performance.now()
   const response = await fetch(buildUrl(url, target), config)
-  const durationMs = Math.round(performance.now() - t)
-  const fields = {
-    'event.action': 'api.request',
-    'event.duration': durationMs * 1_000_000,
-    'url.path': url,
-    'http.response.status_code': response.status,
-    component: 'firecrest',
-  }
-  if (durationMs > 2_000) {
-    logger.warn(fields, `Slow api.request: ${url} ${durationMs}ms`)
-  } else {
-    logger.debug(fields, `api.request`)
-  }
   return await handleReponse(response, target, jsonResponse)
 }
 

--- a/app/apis/status-api.server.ts
+++ b/app/apis/status-api.server.ts
@@ -44,6 +44,10 @@ export const getSystemNodes = async (
   systemName: string,
   request: Request | null = null,
 ): Promise<GetSystemNodesResponse> => {
+  logger.debug(
+    { 'event.action': 'api.request.start', 'url.path': `/status/${systemName}/nodes`, component: 'firecrest' },
+    `api.request.start: /status/${systemName}/nodes`,
+  )
   const t = performance.now()
   const result = await _getSystemNodes(accessToken, systemName, request)
   logCall(`/status/${systemName}/nodes`, t)

--- a/app/apis/status-api.server.ts
+++ b/app/apis/status-api.server.ts
@@ -1,0 +1,51 @@
+/*************************************************************************
+ Copyright (c) 2025, ETH Zurich. All rights reserved.
+
+  Please, refer to the LICENSE file in the root directory.
+  SPDX-License-Identifier: BSD-3-Clause
+*************************************************************************/
+
+// Thin server-only wrappers around status-api that add ECS timing logs.
+// status-api.ts itself cannot import logger.server (no .server suffix →
+// included in the client bundle). This file carries the .server suffix
+// so Vite excludes it from the client bundle.
+
+import logger from '~/logger/logger.server'
+import { getSystems as _getSystems, getSystemNodes as _getSystemNodes } from './status-api'
+import type { GetSystemsResponse, GetSystemNodesResponse } from '~/types/api-status'
+
+function logCall(urlPath: string, startMs: number) {
+  const durationMs = Math.round(performance.now() - startMs)
+  const fields = {
+    'event.action': 'api.request',
+    'event.duration': durationMs * 1_000_000,
+    'url.path': urlPath,
+    component: 'firecrest',
+  }
+  if (durationMs > 2_000) {
+    logger.warn(fields, `Slow api.request: ${urlPath} ${durationMs}ms`)
+  } else {
+    logger.debug(fields, 'api.request')
+  }
+}
+
+export const getSystems = async (
+  accessToken: string,
+  request: Request | null = null,
+): Promise<GetSystemsResponse> => {
+  const t = performance.now()
+  const result = await _getSystems(accessToken, request)
+  logCall('/status/systems', t)
+  return result
+}
+
+export const getSystemNodes = async (
+  accessToken: string,
+  systemName: string,
+  request: Request | null = null,
+): Promise<GetSystemNodesResponse> => {
+  const t = performance.now()
+  const result = await _getSystemNodes(accessToken, systemName, request)
+  logCall(`/status/${systemName}/nodes`, t)
+  return result
+}

--- a/app/configs/base.config.ts
+++ b/app/configs/base.config.ts
@@ -12,6 +12,7 @@ import { getEnvVariable } from '~/helpers/env-helper'
 
 const base = {
   nodeEnv: getEnvVariable(env, 'NODE_ENV'),
+  cookieSecure: getEnvVariable(env, 'COOKIE_SECURE', false, 'true') !== 'false',
   appName: getEnvVariable(env, 'APP_NAME', false, 'App name'),
   companyName: getEnvVariable(env, 'COMPANY_NAME', false, 'Company name'),
   appVersion: getEnvVariable(env, 'APP_VERSION'),

--- a/app/helpers/notification-helper.ts
+++ b/app/helpers/notification-helper.ts
@@ -120,10 +120,10 @@ export const notifyErrorMessage = async (
 
 export const getNotificationMessage = async (request: Request, headers: Headers) => {
   const session = await getSession(request.headers.get('Cookie'))
-  let notificationMessages = []
-  if (session.has(SESSION_KEY)) {
-    notificationMessages = session.get(SESSION_KEY)
+  if (!session.has(SESSION_KEY)) {
+    return []
   }
+  const notificationMessages = session.get(SESSION_KEY)
   headers.append('Set-Cookie', await commitSession(session))
   return notificationMessages
 }

--- a/app/helpers/promise-helper.ts
+++ b/app/helpers/promise-helper.ts
@@ -6,7 +6,9 @@
 *************************************************************************/
 
 export const ABORT_DELAY_MS = 35_000
-export const DEFERRED_PROMISE_TIMEOUT_MS = Math.floor(ABORT_DELAY_MS * 0.95)
+// Timeout for per-system deferred data (nodes, etc). Kept well below ABORT_DELAY_MS
+// so the card shows "unavailable" quickly rather than blocking the stream.
+export const DEFERRED_PROMISE_TIMEOUT_MS = 10_000
 
 export async function promiseWithTimeout<T>(
   promise: Promise<T>,

--- a/app/helpers/promise-helper.ts
+++ b/app/helpers/promise-helper.ts
@@ -6,9 +6,8 @@
 *************************************************************************/
 
 export const ABORT_DELAY_MS = 35_000
-// Timeout for per-system deferred data (nodes, etc). Kept well below ABORT_DELAY_MS
-// so the card shows "unavailable" quickly rather than blocking the stream.
-export const DEFERRED_PROMISE_TIMEOUT_MS = 10_000
+// Timeout for async data loading (deferred routes and client-side resource routes).
+export const DEFERRED_PROMISE_TIMEOUT_MS = 20_000
 
 export async function promiseWithTimeout<T>(
   promise: Promise<T>,

--- a/app/modules/dashboard/components/views/DashboardView.tsx
+++ b/app/modules/dashboard/components/views/DashboardView.tsx
@@ -15,13 +15,13 @@ import SystemsStatusStat from '~/modules/status/components/stats/SystemsStatusSt
 
 interface DashboardViewProps {
   systems: any[]
-  systemsNodesPromises: Record<string, Promise<SystemNodesOverview | null>>
+  systemsNodesPromise: Promise<Record<string, Promise<SystemNodesOverview | null>>>
 }
 
-const DashboardView: React.FC<DashboardViewProps> = ({ systems, systemsNodesPromises }) => {
+const DashboardView: React.FC<DashboardViewProps> = ({ systems, systemsNodesPromise }) => {
   return (
     <SimpleView title='Dashboard' size={SimpleViewSize.FULL}>
-      <SystemsStatusStat systems={systems} systemsNodesPromises={systemsNodesPromises} />
+      <SystemsStatusStat systems={systems} systemsNodesPromise={systemsNodesPromise} />
     </SimpleView>
   )
 }

--- a/app/modules/dashboard/components/views/DashboardView.tsx
+++ b/app/modules/dashboard/components/views/DashboardView.tsx
@@ -6,8 +6,6 @@
 *************************************************************************/
 
 import React from 'react'
-// types
-import type { SystemNodesOverview } from '~/types/api-status'
 // views
 import SimpleView, { SimpleViewSize } from '~/components/views/SimpleView'
 // stats
@@ -15,13 +13,12 @@ import SystemsStatusStat from '~/modules/status/components/stats/SystemsStatusSt
 
 interface DashboardViewProps {
   systems: any[]
-  systemsNodesPromise: Promise<Record<string, Promise<SystemNodesOverview | null>>>
 }
 
-const DashboardView: React.FC<DashboardViewProps> = ({ systems, systemsNodesPromise }) => {
+const DashboardView: React.FC<DashboardViewProps> = ({ systems }) => {
   return (
     <SimpleView title='Dashboard' size={SimpleViewSize.FULL}>
-      <SystemsStatusStat systems={systems} systemsNodesPromise={systemsNodesPromise} />
+      <SystemsStatusStat systems={systems} />
     </SimpleView>
   )
 }

--- a/app/modules/status/components/stats/SystemsStatusStat.tsx
+++ b/app/modules/status/components/stats/SystemsStatusStat.tsx
@@ -6,8 +6,8 @@
 *************************************************************************/
 
 import _ from 'lodash'
-import React, { Suspense, useState } from 'react'
-import { Await } from '@remix-run/react'
+import React, { useEffect, useState } from 'react'
+import { useFetcher } from '@remix-run/react'
 import prettyMilliseconds from 'pretty-ms'
 import {
   CheckCircleIcon,
@@ -311,34 +311,45 @@ const SystemStatusStat: React.FC<SystemStatusStatProps> = ({
   )
 }
 
-const SystemsStatusStatList: React.FC<any> = ({ systems, systemsNodesPromise }) => {
+const NODES_RETRY_INTERVAL_MS = 30_000
+
+const SystemStatusStatCard: React.FC<{ system: any }> = ({ system }) => {
+  const fetcher = useFetcher<SystemNodesOverview | null>()
+
+  // Initial load on mount
+  useEffect(() => {
+    fetcher.load(`/api/status/${system.name}/nodes`)
+  }, [system.name])
+
+  // Retry after NODES_RETRY_INTERVAL_MS if the last response was null (unavailable)
+  useEffect(() => {
+    if (fetcher.state !== 'idle' || fetcher.data !== null) return
+    const timer = setTimeout(() => {
+      fetcher.load(`/api/status/${system.name}/nodes`)
+    }, NODES_RETRY_INTERVAL_MS)
+    return () => clearTimeout(timer)
+  }, [fetcher.state, fetcher.data, system.name])
+
+  // Show loading skeleton while a request is in flight (initial load or retry)
+  const nodes = fetcher.state === 'loading' ? undefined : fetcher.data
+  return <SystemStatusStat system={system} nodes={nodes} />
+}
+
+const SystemsStatusStatList: React.FC<{ systems: any[] }> = ({ systems }) => {
   return (
     <div className='mt-2 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-2 items-start'>
       {systems &&
         systems.length > 0 &&
-        systems.map((system: any) => (
-          <Suspense key={system.name} fallback={<SystemStatusStat system={system} />}>
-            <Await
-              resolve={systemsNodesPromise.then(
-                (map: Record<string, Promise<SystemNodesOverview | null>>) => map[system.name],
-              )}
-              errorElement={<SystemStatusStat system={system} nodes={null} />}
-            >
-              {(nodes: SystemNodesOverview | null) => (
-                <SystemStatusStat system={system} nodes={nodes ?? undefined} />
-              )}
-            </Await>
-          </Suspense>
-        ))}
+        systems.map((system: any) => <SystemStatusStatCard key={system.name} system={system} />)}
     </div>
   )
 }
 
-const SystemsStatusStat: React.FC<any> = ({ systems, systemsNodesPromise, className = '' }: any) => {
+const SystemsStatusStat: React.FC<{ systems: any[]; className?: string }> = ({ systems, className = '' }) => {
   return (
     <div className={classNames('mb-4', className)}>
       <h3 className='text-base font-semibold leading-6 text-gray-900'>Systems status</h3>
-      <SystemsStatusStatList systems={systems} systemsNodesPromise={systemsNodesPromise} />
+      <SystemsStatusStatList systems={systems} />
     </div>
   )
 }

--- a/app/modules/status/components/stats/SystemsStatusStat.tsx
+++ b/app/modules/status/components/stats/SystemsStatusStat.tsx
@@ -239,49 +239,49 @@ const SystemStatusStat: React.FC<SystemStatusStatProps> = ({
           <LabelBadge color={LabelColor.BLUE}>{ssh.host}</LabelBadge>
         </div>
         <div className='ml-16 mt-3'>
-          <span className='text-sm text-gray-500 mb-6'>
-          Nodes status
-          </span>
-          <div className='flex justify-between text-xs text-gray-500 mb-1'>
-            <span className='flex items-center gap-3'>
-              <span className='flex items-center gap-1'>
-                <span className='inline-block w-2 h-2 rounded-full bg-green-500' />
-                {nodes?.available} Idle
-              </span>
-              <span className='flex items-center gap-1'>
-                <span className='inline-block w-2 h-2 rounded-full bg-yellow-400' />
-                {nodes?.allocated} Allocated
-              </span>
-              <span className='flex items-center gap-1'>
-                <span className='inline-block w-2 h-2 rounded-full bg-gray-300' />
-                {nodes?.unavailable} Unavailable
-              </span>
-            </span>
-            {nodes === undefined && <span className='italic text-gray-400'>Loading...</span>}
-            {nodes === null && (
-              <span className='italic text-red-400'>Node data unavailable</span>
-            )}
-            {nodes != null && (
-              <span>
-                {nodes.total} Total
-              </span>
-            )}
-          </div>
-          <div className='w-full bg-gray-200 rounded-full h-2 flex overflow-hidden'>
-            {nodes === undefined && <div className='bg-gray-300 h-2 w-full animate-pulse' />}
-            {nodes != null && (
-              <>
-                <div
-                  className='bg-green-500 h-2 transition-all duration-300'
-                  style={{ width: `${idlePercent}%` }}
-                />
-                <div
-                  className='bg-yellow-400 h-2 transition-all duration-300'
-                  style={{ width: `${allocPercent}%` }}
-                />
-              </>
-            )}
-          </div>
+          <span className='text-sm text-gray-500 mb-6'>Nodes status</span>
+          {nodes === null ? (
+            <div className='flex items-center gap-2 text-sm text-amber-600 mt-1'>
+              <ExclamationCircleIcon className='h-4 w-4 flex-shrink-0' aria-hidden='true' />
+              <span>Node data unavailable — system may be slow or unreachable</span>
+            </div>
+          ) : (
+            <>
+              <div className='flex justify-between text-xs text-gray-500 mb-1'>
+                <span className='flex items-center gap-3'>
+                  <span className='flex items-center gap-1'>
+                    <span className='inline-block w-2 h-2 rounded-full bg-green-500' />
+                    {nodes?.available} Idle
+                  </span>
+                  <span className='flex items-center gap-1'>
+                    <span className='inline-block w-2 h-2 rounded-full bg-yellow-400' />
+                    {nodes?.allocated} Allocated
+                  </span>
+                  <span className='flex items-center gap-1'>
+                    <span className='inline-block w-2 h-2 rounded-full bg-gray-300' />
+                    {nodes?.unavailable} Unavailable
+                  </span>
+                </span>
+                {nodes === undefined && <span className='italic text-gray-400'>Loading...</span>}
+                {nodes != null && <span>{nodes.total} Total</span>}
+              </div>
+              <div className='w-full bg-gray-200 rounded-full h-2 flex overflow-hidden'>
+                {nodes === undefined && <div className='bg-gray-300 h-2 w-full animate-pulse' />}
+                {nodes != null && (
+                  <>
+                    <div
+                      className='bg-green-500 h-2 transition-all duration-300'
+                      style={{ width: `${idlePercent}%` }}
+                    />
+                    <div
+                      className='bg-yellow-400 h-2 transition-all duration-300'
+                      style={{ width: `${allocPercent}%` }}
+                    />
+                  </>
+                )}
+              </div>
+            </>
+          )}
         </div>
       </div>
       {viewAll && <SystemHealthDetailTable system={system} servicesHealth={servicesHealth} />}
@@ -311,7 +311,7 @@ const SystemStatusStat: React.FC<SystemStatusStatProps> = ({
   )
 }
 
-const SystemsStatusStatList: React.FC<any> = ({ systems, systemsNodesPromises }) => {
+const SystemsStatusStatList: React.FC<any> = ({ systems, systemsNodesPromise }) => {
   return (
     <div className='mt-2 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-2 items-start'>
       {systems &&
@@ -319,8 +319,10 @@ const SystemsStatusStatList: React.FC<any> = ({ systems, systemsNodesPromises })
         systems.map((system: any) => (
           <Suspense key={system.name} fallback={<SystemStatusStat system={system} />}>
             <Await
-              resolve={systemsNodesPromises?.[system.name]}
-              errorElement={<SystemStatusStat system={system} />}
+              resolve={systemsNodesPromise.then(
+                (map: Record<string, Promise<SystemNodesOverview | null>>) => map[system.name],
+              )}
+              errorElement={<SystemStatusStat system={system} nodes={null} />}
             >
               {(nodes: SystemNodesOverview | null) => (
                 <SystemStatusStat system={system} nodes={nodes ?? undefined} />
@@ -332,11 +334,11 @@ const SystemsStatusStatList: React.FC<any> = ({ systems, systemsNodesPromises })
   )
 }
 
-const SystemsStatusStat: React.FC<any> = ({ systems, systemsNodesPromises, className = '' }: any) => {
+const SystemsStatusStat: React.FC<any> = ({ systems, systemsNodesPromise, className = '' }: any) => {
   return (
     <div className={classNames('mb-4', className)}>
       <h3 className='text-base font-semibold leading-6 text-gray-900'>Systems status</h3>
-      <SystemsStatusStatList systems={systems} systemsNodesPromises={systemsNodesPromises} />
+      <SystemsStatusStatList systems={systems} systemsNodesPromise={systemsNodesPromise} />
     </div>
   )
 }

--- a/app/routes/_app._index.tsx
+++ b/app/routes/_app._index.tsx
@@ -5,8 +5,7 @@
   SPDX-License-Identifier: BSD-3-Clause
 *************************************************************************/
 
-import { Suspense } from 'react'
-import { useLoaderData, useRouteError, Await } from '@remix-run/react'
+import { useLoaderData, useRouteError } from '@remix-run/react'
 import { data } from '@remix-run/node'
 import type { LoaderFunctionArgs } from '@remix-run/node'
 // loggers
@@ -26,8 +25,6 @@ import type { SystemNodesOverview } from '~/types/api-status'
 // views
 import ErrorView from '~/components/views/ErrorView'
 import DashboardView from '~/modules/dashboard/components/views/DashboardView'
-// spinners
-import LoadingSpinner from '~/components/spinners/LoadingSpinner'
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const loaderStart = performance.now()
@@ -85,15 +82,9 @@ export default function AppIndexRoute() {
   const { systemsNodesPromise } = useLoaderData<typeof loader>() as unknown as {
     systemsNodesPromise: Promise<Record<string, Promise<SystemNodesOverview | null>>>
   }
-  return (
-    <Suspense fallback={<LoadingSpinner className='h-full' />}>
-      <Await resolve={systemsNodesPromise}>
-        {(systemsNodesPromises) => (
-          <DashboardView systems={systems} systemsNodesPromises={systemsNodesPromises} />
-        )}
-      </Await>
-    </Suspense>
-  )
+  // Pass the outer promise directly — each system card chains its own per-system
+  // promise so the card grid renders immediately without an outer Suspense boundary.
+  return <DashboardView systems={systems} systemsNodesPromise={systemsNodesPromise} />
 }
 
 export function ErrorBoundary() {

--- a/app/routes/_app._index.tsx
+++ b/app/routes/_app._index.tsx
@@ -5,86 +5,33 @@
   SPDX-License-Identifier: BSD-3-Clause
 *************************************************************************/
 
-import { useLoaderData, useRouteError } from '@remix-run/react'
+import { useRouteError } from '@remix-run/react'
 import { data } from '@remix-run/node'
 import type { LoaderFunctionArgs } from '@remix-run/node'
-// loggers
-import logger from '~/logger/logger.server'
 // helpers
 import { logInfoHttp } from '~/helpers/log-helper'
 import { LogPage } from '~/helpers/log-labels'
-import { promiseWithTimeout, DEFERRED_PROMISE_TIMEOUT_MS } from '~/helpers/promise-helper'
 // utils
-import { requireAuth, getAuthAccessToken } from '~/utils/auth.server'
+import { requireAuth } from '~/utils/auth.server'
 // contexts
 import { useSystem } from '~/contexts/SystemContext'
-// apis
-import { getSystems, getSystemNodes } from '~/apis/status-api.server'
-// types
-import type { SystemNodesOverview } from '~/types/api-status'
 // views
 import ErrorView from '~/components/views/ErrorView'
 import DashboardView from '~/modules/dashboard/components/views/DashboardView'
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
-  const loaderStart = performance.now()
-  // Check authentication
   const { auth } = await requireAuth(request)
   logInfoHttp({
     eventAction: LogPage.INDEX,
     request: request,
     extraInfo: { username: auth.user.username },
   })
-  // Get auth access token
-  const accessToken = await getAuthAccessToken(request)
-  // Chain getSystems (shared deduped promise) into per-system node promises without
-  // awaiting — loader returns immediately so the shell renders before the HTTP call.
-  const nodeState = (n: { state: string | string[] }) =>
-    (Array.isArray(n.state) ? n.state[0] : n.state).toLowerCase()
-  const systemsNodesPromise = getSystems(accessToken, request).then(({ systems }) =>
-    Object.fromEntries(
-      systems.map((system) => [
-        system.name,
-        promiseWithTimeout(
-          getSystemNodes(accessToken, system.name, request),
-          DEFERRED_PROMISE_TIMEOUT_MS,
-          `Loading nodes for ${system.name} timed out.`,
-        )
-          .then(({ nodes }) => ({
-            available: nodes.filter((n) => nodeState(n) === 'idle').length,
-            allocated: nodes.filter((n) => ['alloc', 'allocated'].includes(nodeState(n))).length,
-            unavailable:
-              nodes.length -
-              nodes.filter((n) => nodeState(n) === 'idle').length -
-              nodes.filter((n) => ['alloc', 'allocated'].includes(nodeState(n))).length,
-            total: nodes.length,
-          } as SystemNodesOverview))
-          .catch((error) => {
-            const msg = error instanceof Response ? `${error.status} ${error.statusText}` : error
-            console.warn(`Failed to load nodes for system ${system.name}:`, msg)
-            return null
-          }),
-      ]),
-    ) as Record<string, Promise<SystemNodesOverview | null>>,
-  )
-  logger.debug({
-    'event.action': 'loader.complete',
-    'event.duration': Math.round(performance.now() - loaderStart) * 1_000_000,
-    'url.path': '/_app/_index',
-    component: 'loader',
-  }, 'loader.complete')
-  return data({ systemsNodesPromise })
+  return data({})
 }
 
 export default function AppIndexRoute() {
   const { systems } = useSystem()
-  // Cast needed: Remix's JsonifyObject strips Promise wrappers from deferred loader data
-  const { systemsNodesPromise } = useLoaderData<typeof loader>() as unknown as {
-    systemsNodesPromise: Promise<Record<string, Promise<SystemNodesOverview | null>>>
-  }
-  // Pass the outer promise directly — each system card chains its own per-system
-  // promise so the card grid renders immediately without an outer Suspense boundary.
-  return <DashboardView systems={systems} systemsNodesPromise={systemsNodesPromise} />
+  return <DashboardView systems={systems} />
 }
 
 export function ErrorBoundary() {

--- a/app/routes/_app._index.tsx
+++ b/app/routes/_app._index.tsx
@@ -10,6 +10,7 @@ import { useLoaderData, useRouteError, Await } from '@remix-run/react'
 import { data } from '@remix-run/node'
 import type { LoaderFunctionArgs } from '@remix-run/node'
 // loggers
+import logger from '~/logger/logger.server'
 // helpers
 import { logInfoHttp } from '~/helpers/log-helper'
 import { LogPage } from '~/helpers/log-labels'
@@ -19,7 +20,7 @@ import { requireAuth, getAuthAccessToken } from '~/utils/auth.server'
 // contexts
 import { useSystem } from '~/contexts/SystemContext'
 // apis
-import { getSystems, getSystemNodes } from '~/apis/status-api'
+import { getSystems, getSystemNodes } from '~/apis/status-api.server'
 // types
 import type { SystemNodesOverview } from '~/types/api-status'
 // views
@@ -29,6 +30,7 @@ import DashboardView from '~/modules/dashboard/components/views/DashboardView'
 import LoadingSpinner from '~/components/spinners/LoadingSpinner'
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
+  const loaderStart = performance.now()
   // Check authentication
   const { auth } = await requireAuth(request)
   logInfoHttp({
@@ -68,6 +70,12 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
       ]),
     ) as Record<string, Promise<SystemNodesOverview | null>>,
   )
+  logger.debug({
+    'event.action': 'loader.complete',
+    'event.duration': Math.round(performance.now() - loaderStart) * 1_000_000,
+    'url.path': '/_app/_index',
+    component: 'loader',
+  }, 'loader.complete')
   return data({ systemsNodesPromise })
 }
 

--- a/app/routes/_app.tsx
+++ b/app/routes/_app.tsx
@@ -14,7 +14,7 @@ import stylesheet from '~/styles/app.css?url'
 // configs
 import base from '~/configs/base.config'
 // apis
-import { getSystems } from '~/apis/status-api'
+import { getSystems } from '~/apis/status-api.server'
 // layouts
 import AppLayout from '~/layouts/AppLayout'
 // helpers
@@ -22,6 +22,8 @@ import { getNotificationMessage } from '~/helpers/notification-helper'
 // utils
 import { requireAuth, getAuthAccessToken } from '~/utils/auth.server'
 import { SystemProvider } from '~/contexts/SystemContext'
+// logger
+import logger from '~/logger/logger.server'
 // spinners
 import LoadingSpinner from '~/components/spinners/LoadingSpinner'
 // types
@@ -30,6 +32,7 @@ import type { System } from '~/types/api-status'
 export const links: LinksFunction = () => [{ rel: 'stylesheet', href: stylesheet }]
 
 export const loader: LoaderFunction = async ({ request, params }: LoaderFunctionArgs) => {
+  const loaderStart = performance.now()
   // Check authentication
   const { auth } = await requireAuth(request)
   // Get auth access token
@@ -42,6 +45,12 @@ export const loader: LoaderFunction = async ({ request, params }: LoaderFunction
   const notificationMessages = await getNotificationMessage(request, headers)
   // Fire getSystems without awaiting — page renders immediately, systems stream in
   const systemsPromise = getSystems(accessToken, request).then(({ systems }) => systems)
+  logger.debug({
+    'event.action': 'loader.complete',
+    'event.duration': Math.round(performance.now() - loaderStart) * 1_000_000,
+    'url.path': '/_app',
+    component: 'loader',
+  }, 'loader.complete')
   return data(
     {
       environment: base.environment,

--- a/app/routes/api.status.$systemName.nodes.tsx
+++ b/app/routes/api.status.$systemName.nodes.tsx
@@ -1,0 +1,47 @@
+/*************************************************************************
+ Copyright (c) 2025, ETH Zurich. All rights reserved.
+
+  Please, refer to the LICENSE file in the root directory.
+  SPDX-License-Identifier: BSD-3-Clause
+*************************************************************************/
+
+import { data } from '@remix-run/node'
+import type { LoaderFunctionArgs } from '@remix-run/node'
+// utils
+import { getAuthAccessToken } from '~/utils/auth.server'
+// apis
+import { getSystemNodes } from '~/apis/status-api.server'
+// helpers
+import { promiseWithTimeout, DEFERRED_PROMISE_TIMEOUT_MS } from '~/helpers/promise-helper'
+// types
+import type { SystemNodesOverview } from '~/types/api-status'
+
+export const loader = async ({ request, params }: LoaderFunctionArgs) => {
+  const headers = new Headers()
+  // Auth errors (unauthenticated/expired session) propagate as 401 — not caught below.
+  const accessToken = await getAuthAccessToken(request, headers)
+  const systemName = params.systemName!
+  const nodeState = (n: { state: string | string[] }) =>
+    (Array.isArray(n.state) ? n.state[0] : n.state).toLowerCase()
+  try {
+    const { nodes } = await promiseWithTimeout(
+      getSystemNodes(accessToken, systemName, request),
+      DEFERRED_PROMISE_TIMEOUT_MS,
+      `Loading nodes for ${systemName} timed out.`,
+    )
+    return data<SystemNodesOverview>(
+      {
+        available: nodes.filter((n) => nodeState(n) === 'idle').length,
+        allocated: nodes.filter((n) => ['alloc', 'allocated'].includes(nodeState(n))).length,
+        unavailable:
+          nodes.length -
+          nodes.filter((n) => nodeState(n) === 'idle').length -
+          nodes.filter((n) => ['alloc', 'allocated'].includes(nodeState(n))).length,
+        total: nodes.length,
+      },
+      { headers },
+    )
+  } catch {
+    return data<null>(null, { headers })
+  }
+}

--- a/app/utils/auth.server.ts
+++ b/app/utils/auth.server.ts
@@ -14,7 +14,9 @@ import type { Auth } from '~/types/auth'
 // configs
 import oidc from '~/configs/oidc.config'
 // utils
-import { getSession, sessionStorage } from './session.server'
+import { getSession, commitSession, destroySession, sessionStorage } from './session.server'
+// logger
+import logger from '~/logger/logger.server'
 // errors
 import { HttpError } from '~/errors/HttpError'
 import { ReasonErrors } from '~/errors/reason-errors'
@@ -38,10 +40,33 @@ interface OidcProfile extends OAuth2Profile {
 let _discovery: OidcDiscoveryDocument | null = null
 let _authenticator: Authenticator<Auth> | null = null
 
+// Per-request session cache: eliminates duplicate Valkey GETs when requireAuth and
+// getAuthAccessToken are called sequentially in the same loader.
+const _sessionCache = new WeakMap<Request, Promise<any>>()
+
+function getCachedSession(request: Request): Promise<any> {
+  if (!_sessionCache.has(request)) {
+    _sessionCache.set(request, getSession(request.headers.get('Cookie')))
+  }
+  return _sessionCache.get(request)!
+}
+
+function logOidcOp(action: string, startMs: number) {
+  const durationMs = Math.round(performance.now() - startMs)
+  const fields = { 'event.action': action, 'event.duration': durationMs * 1_000_000, component: 'oidc' }
+  if (durationMs > 1_000) {
+    logger.warn(fields, `Slow ${action}: ${durationMs}ms`)
+  } else {
+    logger.debug(fields, action)
+  }
+}
+
 async function fetchDiscovery(): Promise<OidcDiscoveryDocument> {
   if (_discovery) return _discovery
   const url = `${oidc.issuerUrl}/.well-known/openid-configuration`
+  const t = performance.now()
   const response = await fetch(url)
+  logOidcOp('oidc.discovery', t)
   if (!response.ok) {
     throw new Error(
       `Failed to fetch OIDC discovery document from ${url}: ${response.statusText}`,
@@ -81,9 +106,11 @@ class OidcStrategy extends OAuth2Strategy<Auth, OidcProfile> {
   }
 
   protected async userProfile(accessToken: string): Promise<OidcProfile> {
+    const t = performance.now()
     const response = await fetch(this.userinfoURL, {
       headers: { Authorization: `Bearer ${accessToken}` },
     })
+    logOidcOp('oidc.userinfo', t)
     if (!response.ok) {
       throw new Error(`Failed to fetch OIDC userinfo: ${response.statusText}`)
     }
@@ -149,7 +176,7 @@ export async function getLogoutUrl(): Promise<string> {
 }
 
 export async function getAuth(request: Request) {
-  const session = await getSession(request.headers.get('Cookie'))
+  const session = await getCachedSession(request)
   return session.get(AUTH_SESSION_KEY)
 }
 
@@ -166,12 +193,10 @@ export async function getAuthTokens(request: Request) {
 }
 
 export async function requireAuth(request: Request, failureRedirect = '/login') {
-  const authenticator = await getAuthenticator()
+  const auth = await getAuth(request)
   const url = new URL(request.url)
   const returnTo = `${url.pathname}${url.search}`
-  const auth = await authenticator.isAuthenticated(request, {
-    failureRedirect: `${failureRedirect}?returnTo=${encodeURIComponent(returnTo)}`,
-  })
+  if (!auth) throw redirect(`${failureRedirect}?returnTo=${encodeURIComponent(returnTo)}`)
   return { auth, returnTo }
 }
 
@@ -186,8 +211,8 @@ export async function getAuthAccessToken(request: Request, headers = new Headers
   try {
     const authTokens = await getAuthTokens(request)
     if (!authTokens || !authTokens.accessToken) {
-      const session = await getSession(request.headers.get('Cookie'))
-      headers.append('Set-Cookie', await sessionStorage.destroySession(session))
+      const session = await getCachedSession(request)
+      headers.append('Set-Cookie', await destroySession(session))
       if (request.method === 'GET') {
         const url = request.url
         if (url.indexOf('/api/') < 0) {
@@ -223,9 +248,9 @@ export async function getAuthAccessToken(request: Request, headers = new Headers
           refreshToken: refresh_token,
           expirationDate: expirationDate,
         }
-        const session = await getSession(request.headers.get('Cookie'))
+        const session = await getCachedSession(request)
         session.set(AUTH_SESSION_KEY, auth)
-        headers.append('Set-Cookie', await sessionStorage.commitSession(session))
+        headers.append('Set-Cookie', await commitSession(session))
         if (request.method === 'GET') {
           const url = request.url
           if (url.indexOf('/api/') < 0) {
@@ -254,13 +279,13 @@ const refreshAccessToken = async (request: Request, refreshToken: string) => {
   const body = Object.keys(params)
     .map((key) => encodeURIComponent(key) + '=' + encodeURIComponent(params[key]))
     .join('&')
+  const t = performance.now()
   const response = await fetch(discovery.token_endpoint, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
-    },
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8' },
     body: body,
   })
+  logOidcOp('oidc.token_refresh', t)
   if (!response.ok) {
     const authenticator = await getAuthenticator()
     const logoutUrl = await getLogoutUrl()

--- a/app/utils/auth.server.ts
+++ b/app/utils/auth.server.ts
@@ -260,7 +260,7 @@ export async function getAuthAccessToken(request: Request, headers = new Headers
         return access_token
       })()
       _pendingRefresh.set(cookieKey, refreshPromise)
-      refreshPromise.finally(() => _pendingRefresh.delete(cookieKey))
+      refreshPromise.finally(() => _pendingRefresh.delete(cookieKey)).catch(() => {})
       return refreshPromise
     }
     throw error

--- a/app/utils/auth.server.ts
+++ b/app/utils/auth.server.ts
@@ -40,17 +40,6 @@ interface OidcProfile extends OAuth2Profile {
 let _discovery: OidcDiscoveryDocument | null = null
 let _authenticator: Authenticator<Auth> | null = null
 
-// Per-request session cache: eliminates duplicate Valkey GETs when requireAuth and
-// getAuthAccessToken are called sequentially in the same loader.
-const _sessionCache = new WeakMap<Request, Promise<any>>()
-
-function getCachedSession(request: Request): Promise<any> {
-  if (!_sessionCache.has(request)) {
-    _sessionCache.set(request, getSession(request.headers.get('Cookie')))
-  }
-  return _sessionCache.get(request)!
-}
-
 function logOidcOp(action: string, startMs: number) {
   const durationMs = Math.round(performance.now() - startMs)
   const fields = { 'event.action': action, 'event.duration': durationMs * 1_000_000, component: 'oidc' }
@@ -176,7 +165,7 @@ export async function getLogoutUrl(): Promise<string> {
 }
 
 export async function getAuth(request: Request) {
-  const session = await getCachedSession(request)
+  const session = await getSession(request.headers.get('Cookie'))
   return session.get(AUTH_SESSION_KEY)
 }
 
@@ -211,7 +200,7 @@ export async function getAuthAccessToken(request: Request, headers = new Headers
   try {
     const authTokens = await getAuthTokens(request)
     if (!authTokens || !authTokens.accessToken) {
-      const session = await getCachedSession(request)
+      const session = await getSession(request.headers.get('Cookie'))
       headers.append('Set-Cookie', await destroySession(session))
       if (request.method === 'GET') {
         const url = request.url
@@ -250,7 +239,7 @@ export async function getAuthAccessToken(request: Request, headers = new Headers
           refreshToken: refresh_token,
           expirationDate: expirationDate,
         }
-        const session = await getCachedSession(request)
+        const session = await getSession(request.headers.get('Cookie'))
         session.set(AUTH_SESSION_KEY, auth)
         headers.append('Set-Cookie', await commitSession(session))
         if (request.method === 'GET') {

--- a/app/utils/auth.server.ts
+++ b/app/utils/auth.server.ts
@@ -225,8 +225,10 @@ export async function getAuthAccessToken(request: Request, headers = new Headers
       )
     }
     if (new Date(authTokens.expirationDate) <= new Date()) {
+      logger.debug({ 'event.action': 'auth.token_expired', component: 'oidc' }, 'auth.token_expired')
       throw new AuthorizationError('Token expired')
     }
+    logger.debug({ 'event.action': 'auth.token_valid', component: 'oidc' }, 'auth.token_valid')
     return authTokens.accessToken
   } catch (error) {
     if (error instanceof AuthorizationError) {

--- a/app/utils/session.server.ts
+++ b/app/utils/session.server.ts
@@ -38,20 +38,56 @@ if (redisConfig.active) {
     port: parseInt(redisConfig.port),
     host: redisConfig.host,
     password: redisConfig.authPassword,
+    connectTimeout: 3_000,
+    commandTimeout: 3_000,
+    maxRetriesPerRequest: 2,
   })
-  sessionStorage = createRedisSessionStorage({
-    redis,
-    cookie: sessionCookie,
-  })
-  logger.info('REDIS session')
+  redis.on('connect', () => logger.info({ component: 'valkey' }, 'Valkey connected'))
+  redis.on('ready', () => logger.info({ component: 'valkey' }, 'Valkey ready'))
+  redis.on('error', (err: Error) => logger.error({ err, component: 'valkey' }, 'Valkey error'))
+  redis.on('reconnecting', () => logger.warn({ component: 'valkey' }, 'Valkey reconnecting'))
+  redis.on('close', () => logger.warn({ component: 'valkey' }, 'Valkey connection closed'))
+  sessionStorage = createRedisSessionStorage({ redis, cookie: sessionCookie })
+  logger.info({ component: 'valkey' }, 'Valkey session storage initialised')
 } else {
   sessionStorage = createFileSessionStorage({
-    // The root directory where you want to store the files.
-    // Make sure it's writable!
     dir: base.sessionFileDirPath,
     cookie: sessionCookie,
   })
-  logger.info('FILE session')
+  logger.info('File session storage initialised')
 }
 
-export const { getSession, commitSession, destroySession } = sessionStorage
+function logSessionOp(action: string, startMs: number) {
+  const durationMs = Math.round(performance.now() - startMs)
+  const fields = {
+    'event.action': action,
+    'event.duration': durationMs * 1_000_000,
+    component: 'valkey',
+  }
+  if (durationMs > 500) {
+    logger.warn(fields, `Slow ${action}: ${durationMs}ms`)
+  } else {
+    logger.debug(fields, action)
+  }
+}
+
+export async function getSession(cookie: string | null) {
+  const t = performance.now()
+  const session = await sessionStorage.getSession(cookie)
+  logSessionOp('session.read', t)
+  return session
+}
+
+export async function commitSession(session: any) {
+  const t = performance.now()
+  const cookie = await sessionStorage.commitSession(session)
+  logSessionOp('session.commit', t)
+  return cookie
+}
+
+export async function destroySession(session: any) {
+  const t = performance.now()
+  const cookie = await sessionStorage.destroySession(session)
+  logSessionOp('session.destroy', t)
+  return cookie
+}

--- a/app/utils/session.server.ts
+++ b/app/utils/session.server.ts
@@ -38,9 +38,6 @@ if (redisConfig.active) {
     port: parseInt(redisConfig.port),
     host: redisConfig.host,
     password: redisConfig.authPassword,
-    connectTimeout: 3_000,
-    commandTimeout: 3_000,
-    maxRetriesPerRequest: 2,
   })
   redis.on('connect', () => logger.info({ component: 'valkey' }, 'Valkey connected'))
   redis.on('ready', () => logger.info({ component: 'valkey' }, 'Valkey ready'))

--- a/app/utils/session.server.ts
+++ b/app/utils/session.server.ts
@@ -18,7 +18,7 @@ export const returnToCookie = createCookie('__return-to', {
   path: '/',
   httpOnly: true,
   sameSite: 'lax',
-  secure: base.nodeEnv === 'production', // enable this in prod only
+  secure: base.cookieSecure,
   maxAge: 60, // 1 min: is enough for the round-trip of login
 })
 
@@ -28,7 +28,7 @@ export const sessionCookie = createCookie('__session', {
   path: '/', // remember to add this so the cookie will work in all routes
   httpOnly: true, // for security reasons, make this cookie http only
   secrets: [base.sessionSecret], // replace this with an actual secret
-  secure: base.nodeEnv === 'production', // enable this in prod only
+  secure: base.cookieSecure,
 })
 
 export let sessionStorage: any

--- a/app/utils/session.server.ts
+++ b/app/utils/session.server.ts
@@ -38,6 +38,7 @@ if (redisConfig.active) {
     port: parseInt(redisConfig.port),
     host: redisConfig.host,
     password: redisConfig.authPassword,
+    maxRetriesPerRequest: 3,
   })
   redis.on('connect', () => logger.info({ component: 'valkey' }, 'Valkey connected'))
   redis.on('ready', () => logger.info({ component: 'valkey' }, 'Valkey ready'))

--- a/observability/kibana/latency-queries.md
+++ b/observability/kibana/latency-queries.md
@@ -1,0 +1,138 @@
+# Kibana / Elastic Latency Queries
+
+All queries target the ECS-structured logs emitted by the Remix app (pino + ECS format).
+Fields of interest: `event.action`, `event.duration` (nanoseconds), `component`, `message`,
+`http.request.id` (x-request-id), `log.level`.
+
+---
+
+## 1. Session (Valkey) latency
+
+### Slow session operations (>500 ms)
+
+```kql
+component: "valkey" AND log.level: "warn" AND message: "Slow session*"
+```
+
+Columns to add: `@timestamp`, `event.action`, `event.duration`, `message`, `http.request.id`
+
+### Session latency histogram (all reads)
+
+```kql
+event.action: "session.read"
+```
+
+Use a **Lens → Histogram** visualization with `event.duration` (convert ns → ms: divide by 1e6 in a
+runtime field or set the unit in the axis label). Group by `event.action` to compare `session.read`,
+`session.commit`, and `session.destroy` side by side.
+
+### Valkey connection events (errors / reconnects)
+
+```kql
+component: "valkey" AND (log.level: "error" OR log.level: "warn")
+```
+
+Useful to correlate Valkey reconnect cycles with spikes in session latency. Pin a vertical marker
+on the session latency chart when reconnect events appear.
+
+---
+
+## 2. OIDC / Keycloak latency
+
+### Slow OIDC calls (>1 000 ms)
+
+```kql
+component: "oidc" AND log.level: "warn" AND message: "Slow oidc*"
+```
+
+### All OIDC durations by action
+
+```kql
+component: "oidc"
+```
+
+Split by `event.action` to compare `oidc.discovery`, `oidc.userinfo`, and `oidc.token_refresh`.
+A **Line** chart with a 95th-percentile aggregation on `event.duration` catches tail latency.
+
+### Token refresh frequency
+
+```kql
+event.action: "oidc.token_refresh"
+```
+
+High frequency here relative to unique users indicates short-lived tokens or clock skew between
+the UI server and Keycloak.
+
+---
+
+## 3. Backend API (FirecREST) latency
+
+### Requests by endpoint (slow >5 s → timeout boundary)
+
+```kql
+event.action: "http.request" AND http.request.method: *
+```
+
+Filter to `event.duration > 5000000000` (5 s in ns) to find calls that hit the `AbortSignal.timeout`
+boundary defined in `app/apis/api.ts`.
+
+### `/nodes` endpoint latency (dashboard bottleneck)
+
+```kql
+url.path: *nodes* AND component: "api"
+```
+
+The `/v2/status/{system}/nodes` endpoints are the primary dashboard bottleneck (one deferred
+promise per system). This query tracks their p50/p95 over time.
+
+---
+
+## 4. End-to-end request duration by page
+
+### Dashboard index page load time
+
+```kql
+event.action: "http.response" AND url.path: "/"
+```
+
+Columns: `@timestamp`, `event.duration`, `http.request.id`, `http.response.status_code`
+
+### Correlate all events for a single request
+
+```kql
+http.request.id: "<paste x-request-id here>"
+```
+
+This pulls every log line (session read, OIDC check, API call, response) that shared the same
+`x-request-id`, reconstructing a per-request trace from structured logs.
+
+---
+
+## 5. Composite: session + OIDC + API for the same request
+
+```kql
+http.request.id: "<paste x-request-id here>" AND component: ("valkey" OR "oidc" OR "api")
+```
+
+Sort by `@timestamp` ascending to see the waterfall: session.read → oidc check → API call(s).
+
+---
+
+## 6. Alert thresholds (suggested)
+
+| Metric | KQL filter | Threshold | Severity |
+|---|---|---|---|
+| Slow Valkey read | `event.action: "session.read"` | p95 > 300 ms | warning |
+| Valkey error rate | `component: "valkey" AND log.level: "error"` | >5 / min | critical |
+| OIDC discovery slow | `event.action: "oidc.discovery"` | any > 2 000 ms | warning |
+| Token refresh fail | `event.action: "oidc.token_refresh" AND log.level: "error"` | any | critical |
+| API timeout | `event.duration > 9000000000 AND component: "api"` | any | warning |
+
+---
+
+## Notes
+
+- `event.duration` is stored in **nanoseconds** (ECS spec). Divide by `1e6` for milliseconds.
+- Set `@timestamp` as the primary time field.
+- The `http.request.id` field is populated from the `x-request-id` header threaded through all
+  server-side log calls. It is the primary correlation key across session, OIDC, and API layers.

--- a/observability/kibana/latency-queries.md
+++ b/observability/kibana/latency-queries.md
@@ -67,19 +67,22 @@ the UI server and Keycloak.
 
 ## 3. Backend API (FirecREST) latency
 
-### Requests by endpoint (slow >5 s → timeout boundary)
+### All FirecREST calls with duration
 
 ```kql
-event.action: "http.request" AND http.request.method: *
+component: "firecrest"
 ```
 
-Filter to `event.duration > 5000000000` (5 s in ns) to find calls that hit the `AbortSignal.timeout`
-boundary defined in `app/apis/api.ts`.
+### Slow calls (>2 s, promoted to warn)
+
+```kql
+component: "firecrest" AND log.level: "warn"
+```
 
 ### `/nodes` endpoint latency (dashboard bottleneck)
 
 ```kql
-url.path: *nodes* AND component: "api"
+url.path: *nodes* AND component: "firecrest"
 ```
 
 The `/v2/status/{system}/nodes` endpoints are the primary dashboard bottleneck (one deferred
@@ -111,7 +114,7 @@ This pulls every log line (session read, OIDC check, API call, response) that sh
 ## 5. Composite: session + OIDC + API for the same request
 
 ```kql
-http.request.id: "<paste x-request-id here>" AND component: ("valkey" OR "oidc" OR "api")
+http.request.id: "<paste x-request-id here>" AND component: ("valkey" OR "oidc" OR "firecrest")
 ```
 
 Sort by `@timestamp` ascending to see the waterfall: session.read → oidc check → API call(s).

--- a/observability/traefik/access-log-config.md
+++ b/observability/traefik/access-log-config.md
@@ -1,0 +1,127 @@
+# Traefik Access Log Configuration — Reference Only
+
+> **DO NOT apply to production.**
+> This document records how Traefik access logs and request-ID propagation *could* be configured
+> to complement the application-level latency instrumentation. It is a reference for future
+> platform decisions, not an operational change.
+
+---
+
+## Why this matters
+
+When the Remix UI logs a slow session read or OIDC call the timestamp is relative to when the
+Node process handled the request. Traefik sits in front and already sees the full round-trip time
+(from TLS termination through response completion). Adding Traefik access logs with:
+
+1. `x-request-id` correlation
+2. `requestDuration` (total time at the ingress)
+
+lets you compare the ingress-level duration with the sum of component durations logged by the app.
+If `requestDuration` >> sum of app timings, the gap points to network or buffering overhead inside
+the cluster (e.g. Traefik → pod TCP setup, response buffering before streaming to the client).
+
+---
+
+## Traefik static configuration additions
+
+```yaml
+# traefik.yaml (or equivalent Helm values section)
+accessLog:
+  # Write to stdout so the log collector picks it up alongside the app logs
+  filePath: ""            # empty → stdout
+  format: json
+
+  fields:
+    defaultMode: keep
+    names:
+      # Include these specific fields; drop everything else if bandwidth matters
+      StartUTC: keep
+      Duration: keep       # total request duration in nanoseconds
+      RequestMethod: keep
+      RequestPath: keep
+      RequestProtocol: keep
+      OriginStatus: keep
+      OriginDuration: keep # time waiting for the backend (pod) only
+
+    headers:
+      defaultMode: drop
+      names:
+        # Echo the x-request-id header so logs from Traefik and the app share a key
+        X-Request-Id: keep
+        X-Forwarded-For: keep
+```
+
+### Helm values equivalent (Traefik chart)
+
+```yaml
+additionalArguments:
+  - "--accesslog=true"
+  - "--accesslog.format=json"
+  - "--accesslog.fields.defaultmode=keep"
+  - "--accesslog.fields.headers.defaultmode=drop"
+  - "--accesslog.fields.headers.names.X-Request-Id=keep"
+  - "--accesslog.fields.headers.names.X-Forwarded-For=keep"
+```
+
+---
+
+## x-request-id propagation in dynamic config
+
+Traefik does **not** auto-generate `x-request-id` by default. A middleware is needed:
+
+```yaml
+# traefik dynamic config / IngressRoute CRD
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: requestid
+  namespace: firecrest
+spec:
+  headers:
+    customRequestHeaders:
+      # Generate a UUID if the header is absent; pass through if already set by the client
+      X-Request-Id: ""   # empty string → Traefik generates a random value only if missing
+
+# Attach to IngressRoute:
+# routes:
+#   - middlewares:
+#       - name: requestid
+```
+
+> **Note**: The exact header-generation behaviour depends on the Traefik version. As of v3.x,
+> Traefik does not natively generate UUIDs for missing headers — this requires the
+> `plugin/requestid` community plugin or a dedicated middleware. Verify against the deployed
+> version before proposing this change.
+
+---
+
+## Resulting Kibana correlation query
+
+Once Traefik access logs land in Elastic alongside app logs (same index or aliased), a single
+query returns the full picture per request:
+
+```kql
+X-Request-Id: "<uuid>" OR http.request.id: "<uuid>"
+```
+
+The Traefik entry shows ingress-level `Duration`; the app entries show component-level durations.
+The delta between `Duration` and the sum of `session.read + oidc.* + api.*` durations reveals
+where time is actually spent outside the application.
+
+---
+
+## ECS field mapping for Traefik access logs
+
+If using Filebeat / Elastic Agent with the Traefik module, the JSON fields map as follows:
+
+| Traefik JSON field | ECS field |
+|---|---|
+| `Duration` | `event.duration` (ns) |
+| `StartUTC` | `@timestamp` |
+| `RequestMethod` | `http.request.method` |
+| `RequestPath` | `url.path` |
+| `OriginStatus` | `http.response.status_code` |
+| `X-Request-Id` (header) | `http.request.id` |
+
+Configure the Filebeat pipeline to populate these mappings so Traefik and app log entries share
+the same field names in Kibana.


### PR DESCRIPTION
  ## Summary

  ### Dashboard loading (core fix)

  The dashboard showed a white screen for 10–28 seconds on full page load.
  The root cause was not fully identified — possible contributing factors include
  the Traefik `buffering` middleware (`memResponseBodyBytes: 262144`), other
  upstream proxy buffering, or the slow FirecREST backend causing the Remix
  chunked streaming to stall before reaching the browser.

  The fix addresses the problem at the architecture level: the Remix
  `defer`/`Suspense`/`Await` pattern has been replaced with client-side data
  loading. The page now renders a complete HTML shell immediately on load, and
  each system card independently fetches its node data after hydration. This
  approach is resilient to any proxy or buffering configuration and, as a side
  benefit, naturally enables per-card retry logic when the backend is slow or
  unreachable.

  - Removed `defer`/`Suspense`/`Await` from the dashboard index route
  - Added resource route `GET /api/status/$systemName/nodes` returning
    `SystemNodesOverview | null` as JSON
  - Each system card uses `useFetcher` + `useEffect` to load node data
    independently after hydration — loading skeleton while in flight, amber
    "unavailable" on timeout or error, auto-retry every 30s
  - Added `COOKIE_SECURE` env var (`true` by default) to decouple cookie
    security from `NODE_ENV`, enabling HTTP-only deployments
  - `DEFERRED_PROMISE_TIMEOUT_MS` raised from 10s to 20s

  ### FirecREST API call timing

  - `status-api.server.ts`: `api.request.start` log on every
    `/status/$system/nodes` call; `api.request` on completion with
    `event.duration`; `warn` level when duration exceeds 2s

  ### Valkey event logging

  Connection lifecycle events (connect, ready, error, reconnecting, close)
  are now logged with ECS fields and `component: "valkey"`. Makes Valkey
  outages immediately visible in Kibana and correlatable with session
  latency spikes.

  ### Session operation timing

  `getSession`, `commitSession`, and `destroySession` each emit an ECS log
  entry with `event.duration` (ns). Operations exceeding 500ms are promoted
  to `warn` level.

  ### OIDC operation timing

  `fetchDiscovery`, `userProfile` (userinfo endpoint), and `refreshAccessToken`
  emit OIDC timing logs (`component: "oidc"`, `warn` above 1s). `requireAuth`
  no longer calls `authenticator.isAuthenticated()` — it delegates directly to
  `getAuth()`, removing one redundant session read.

  ### Observability artifacts

  - `observability/kibana/latency-queries.md` — KQL queries for session latency
    histogram, slow ops, Valkey connection events, OIDC timing, and x-request-id
    waterfall correlation
  - `observability/traefik/access-log-config.md` — reference only, not deployed:
    Traefik access log config for ingress-level timing and x-request-id threading

  🤖 Generated with [Claude Code](https://claude.com/claude-code)